### PR TITLE
Add BaseChain to standardize chain construction

### DIFF
--- a/riskgpt/chains/__init__.py
+++ b/riskgpt/chains/__init__.py
@@ -1,7 +1,8 @@
 """Chain package initialization."""
+from .base import BaseChain  # noqa: F401
 from .get_categories import get_categories_chain  # noqa: F401
 
 __all__ = [
+    "BaseChain",
     "get_categories_chain",
 ]
-

--- a/riskgpt/chains/base.py
+++ b/riskgpt/chains/base.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from langchain_core.output_parsers import BaseOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+from langchain_community.callbacks import get_openai_callback
+
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.utils.memory_factory import get_memory
+from riskgpt.models.schemas import ResponseInfo
+
+
+class BaseChain:
+    """Reusable chain setup for prompt -> model -> parser pattern."""
+
+    def __init__(
+        self,
+        prompt_template: str,
+        parser: BaseOutputParser,
+        *,
+        settings: Optional[RiskGPTSettings] = None,
+        prompt_name: str = "",
+    ) -> None:
+        self.settings = settings or RiskGPTSettings()
+        self.prompt_name = prompt_name
+        self.parser = parser
+
+        self.prompt = ChatPromptTemplate.from_template(
+            template=prompt_template,
+            partial_variables=self._partial_variables(),
+        )
+
+        self.model = ChatOpenAI(
+            api_key=self.settings.OPENAI_API_KEY,
+            temperature=self.settings.TEMPERATURE,
+            model=self.settings.OPENAI_MODEL_NAME,
+        )
+
+        self.memory = get_memory(self.settings)
+        self.chain = self.prompt | self.model | self.parser
+
+    def _partial_variables(self) -> Dict[str, str]:
+        fmt = self.parser.get_format_instructions()
+        fmt = fmt.replace('{', '{{').replace('}', '}}')
+        return {"format_instructions": fmt}
+
+    def invoke(self, inputs: Dict[str, Any]):
+        with get_openai_callback() as cb:
+            result = self.chain.invoke(inputs, memory=self.memory)
+            if hasattr(result, "response_info"):
+                result.response_info = ResponseInfo(
+                    consumed_tokens=cb.total_tokens,
+                    total_cost=cb.total_cost,
+                    prompt_name=self.prompt_name,
+                    model_name=self.settings.OPENAI_MODEL_NAME,
+                )
+        return result

--- a/riskgpt/chains/get_categories.py
+++ b/riskgpt/chains/get_categories.py
@@ -1,14 +1,10 @@
-from langchain.chains import LLMChain
 from langchain_core.output_parsers import PydanticOutputParser
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
 
-from langchain_community.callbacks import get_openai_callback
 from riskgpt.utils.prompt_loader import load_prompt
-from riskgpt.utils.memory_factory import get_memory
 from riskgpt.config.settings import RiskGPTSettings
-from riskgpt.models.schemas import CategoryRequest, CategoryResponse, ResponseInfo
+from riskgpt.models.schemas import CategoryRequest, CategoryResponse
 from riskgpt.registry.chain_registry import register
+from .base import BaseChain
 
 
 @register("get_categories")
@@ -16,34 +12,17 @@ def get_categories_chain(request: CategoryRequest) -> CategoryResponse:
     settings = RiskGPTSettings()
     prompt_data = load_prompt("get_categories", version="v1")
 
-
-    template = prompt_data["template"]
     parser = PydanticOutputParser(pydantic_object=CategoryResponse)
-    memory = get_memory(settings)
-    model = ChatOpenAI(
-        api_key=settings.OPENAI_API_KEY,
-        temperature=settings.TEMPERATURE,
-        model=settings.OPENAI_MODEL_NAME
-    )
-
-    format_instructions = parser.get_format_instructions()
-    format_instructions = format_instructions.replace('{', '{{').replace('}', '}}')
-
-    prompt = ChatPromptTemplate.from_template(
-        template=template,
-        partial_variables={"format_instructions": format_instructions}
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_categories",
     )
 
     inputs = request.model_dump()
-    inputs["domain_section"] = f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
 
-    chain = prompt | model | parser
-    with get_openai_callback() as cb:
-        result = chain.invoke(inputs, memory=memory)
-        result.response_info = ResponseInfo(
-            consumed_tokens=cb.total_tokens,
-            total_cost=cb.total_cost,
-            prompt_name="get_categories",
-            model_name=settings.OPENAI_MODEL_NAME
-        )
-    return result
+    return chain.invoke(inputs)


### PR DESCRIPTION
## Summary
- introduce `BaseChain` as reusable building block for chains
- refactor `get_categories_chain` to use `BaseChain`
- export `BaseChain` from `riskgpt.chains`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440311c590832d837c26729ed33667