### PR TITLE
Improve prompt loader

### DIFF
--- a/riskgpt/chains/get_categories.py
+++ b/riskgpt/chains/get_categories.py
@@ -14,7 +14,7 @@ from riskgpt.registry.chain_registry import register
 @register("get_categories")
 def get_categories_chain(request: CategoryRequest) -> CategoryResponse:
     settings = RiskGPTSettings()
-    prompt_data = load_prompt("get_categories", version="v1")
+    prompt_data = load_prompt("get_categories")
 
 
     template = prompt_data["template"]

--- a/riskgpt/config/settings.py
+++ b/riskgpt/config/settings.py
@@ -12,4 +12,5 @@ class RiskGPTSettings(BaseSettings):
     OPENAI_API_KEY: Optional[str] = None
     TEMPERATURE: float = Field(default=0.7, ge=0.0, le=1.0)
     OPENAI_MODEL_NAME: str = Field(default="gpt-4.1-mini")
+    DEFAULT_PROMPT_VERSION: str = Field(default="v1")
 

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -1,6 +1,11 @@
 from pydantic import BaseModel
 from typing import List, Optional
 
+class Prompt(BaseModel):
+    version: str
+    description: str
+    template: str
+
 class ResponseInfo(BaseModel):
     consumed_tokens: int
     total_cost: float

--- a/riskgpt/utils/prompt_loader.py
+++ b/riskgpt/utils/prompt_loader.py
@@ -1,13 +1,23 @@
 import yaml
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.models.schemas import Prompt
 
 
 PROMPT_DIR = Path(__file__).parent.parent / "prompts"
 
-def load_prompt(name: str, version: str = "v1") -> Dict[str, Any]:
+
+def load_prompt(name: str, version: Optional[str] = None) -> Dict[str, Any]:
+    if version is None:
+        settings = RiskGPTSettings()
+        version = settings.DEFAULT_PROMPT_VERSION
+
     path = PROMPT_DIR / name / f"{version}.yaml"
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
-    return data
+
+    prompt = Prompt(**data)
+    return prompt.model_dump()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,9 +36,26 @@ def test_load_prompt(monkeypatch):
     monkeypatch.setitem(sys.modules, "yaml", yaml_stub)
 
     prompt_loader = importlib.reload(importlib.import_module("riskgpt.utils.prompt_loader"))
-    data = prompt_loader.load_prompt("get_categories", "v1")
+    data = prompt_loader.load_prompt("get_categories")
     assert data["version"] == "v1"
     assert "You are a risk analyst." in data["template"]
+
+
+def test_load_prompt_default_version(monkeypatch, tmp_path):
+    prompts_dir = tmp_path / "prompts" / "foo"
+    prompts_dir.mkdir(parents=True)
+    file = prompts_dir / "v2.yaml"
+    file.write_text('version: "v2"\ndescription: "d"\ntemplate: |\n  test')
+
+    import importlib
+    from riskgpt.utils import prompt_loader
+
+    monkeypatch.setattr(prompt_loader, "PROMPT_DIR", tmp_path / "prompts")
+    monkeypatch.setenv("DEFAULT_PROMPT_VERSION", "v2")
+    importlib.reload(prompt_loader)
+
+    data = prompt_loader.load_prompt("foo")
+    assert data["version"] == "v2"
 
 
 def test_validate_category_request_valid():


### PR DESCRIPTION
## Summary
- handle default prompt version via `RiskGPTSettings`
- validate prompts using a new `Prompt` schema
- update `get_categories` chain to rely on default version
- expand tests to exercise prompt loading

## Testing
- `pytest -q` *(fails: 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6844031ebb94832da02491a9b668e32f