### PR TITLE
Add documentation for get_categories chain

### DIFF
--- a/docs/get_categories.md
+++ b/docs/get_categories.md
@@ -1,0 +1,35 @@
+# Get Categories
+
+The `get_categories` chain identifies relevant risk categories for a project description using a language model.
+
+## Input
+
+`CategoryRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `project_description` (`str`): description of the project.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`CategoryResponse`
+- `categories` (`List[str]`): list of detected risk categories.
+- `rationale` (`str | None`): explanation of the categories.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.get_categories import get_categories_chain
+from riskgpt.models.schemas import CategoryRequest
+
+request = CategoryRequest(
+    project_id="123",
+    project_description="An IT project to introduce a new CRM system.",
+    domain_knowledge="The company operates in the B2B market.",
+    language="de"
+)
+
+response = get_categories_chain(request)
+print(response.categories)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,7 @@ RiskGPT is a Python package for analyzing project-related risks and opportunitie
 - Identify specific risks per category
 - Estimate impact using probabilistic methods
 - Support for domain-specific context and memory
+
+## Chains
+
+- [Get Categories](get_categories.md) – determine relevant risk categories for a project description

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ theme:
   name: material
 nav:
   - Home: index.md
+  - Chains:
+      - Get Categories: get_categories.md
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
## Summary
- document chain features in `get_categories.md`
- link chain docs from index
- update navigation in `mkdocs.yml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844033b8378832dbfbbe4ba36b25c73