### PR TITLE
Add pluggable memory factory

### DIFF
--- a/riskgpt/config/memory.py
+++ b/riskgpt/config/memory.py
@@ -1,15 +1,19 @@
-from langchain.memory import ConversationBufferMemory, RedisChatMessageHistory
+"""Configuration helper for memory backends."""
+
 from pydantic import BaseSettings
 from typing import Optional, Literal
 
+from riskgpt.utils.memory_factory import (
+    get_memory as factory_get_memory,
+    register_memory_backend,
+)
+from riskgpt.config.settings import RiskGPTSettings
+
 class MemorySettings(BaseSettings):
+    """Settings for memory creation."""
+
     type: Literal["none", "buffer", "redis"] = "buffer"
     redis_url: Optional[str] = None
 
 def get_memory(settings: MemorySettings = MemorySettings()):
-    if settings.type == "none":
-        return None
-    elif settings.type == "buffer":
-        return ConversationBufferMemory(return_messages=True)
-    elif settings.type == "redis":
-        return RedisChatMessageHistory(url=settings.redis_url)
+    return factory_get_memory(RiskGPTSettings(MEMORY_TYPE=settings.type, REDIS_URL=settings.redis_url))

--- a/riskgpt/utils/memory_factory.py
+++ b/riskgpt/utils/memory_factory.py
@@ -1,12 +1,57 @@
-from langchain.memory.buffer import ConversationBufferMemory
-from typing import Optional
+"""Factory for creating different memory backends."""
+
+from typing import Callable, Dict, Optional
+
+from langchain.memory import ConversationBufferMemory, RedisChatMessageHistory
+
 from riskgpt.config.settings import RiskGPTSettings
 
+
+# Mapping of memory backend names to creator callables
+_CREATORS: Dict[str, Callable[[RiskGPTSettings], Optional[object]]] = {}
+
+
+def register_memory_backend(name: str, creator: Callable[[RiskGPTSettings], Optional[object]]) -> None:
+    """Register a new memory backend.
+
+    Parameters
+    ----------
+    name:
+        Identifier for the memory backend.
+    creator:
+        Callable that accepts :class:`RiskGPTSettings` and returns a
+        memory instance.
+    """
+
+    _CREATORS[name] = creator
+
+def _buffer_memory(_: RiskGPTSettings) -> ConversationBufferMemory:
+    """Default in-memory conversation buffer."""
+
+    return ConversationBufferMemory(return_messages=True)
+
+
+def _redis_memory(settings: RiskGPTSettings) -> ConversationBufferMemory:
+    """Redis-based conversation memory."""
+
+    if not settings.REDIS_URL:
+        raise ValueError("REDIS_URL must be set for redis memory backend")
+    history = RedisChatMessageHistory(url=settings.REDIS_URL)
+    return ConversationBufferMemory(chat_memory=history, return_messages=True)
+
+
+# Register built-in backends
+register_memory_backend("none", lambda _s: None)
+register_memory_backend("buffer", _buffer_memory)
+register_memory_backend("redis", _redis_memory)
+
+
 def get_memory(settings: RiskGPTSettings = RiskGPTSettings()) -> Optional[object]:
-    if settings.MEMORY_TYPE == "none":
-        return None
-    elif settings.MEMORY_TYPE == "buffer":
-        return ConversationBufferMemory(return_messages=True)
-    elif settings.MEMORY_TYPE == "redis":
-        raise ValueError("Unsupported memory type: redis. Please configure Redis memory support.")
-    return None
+    """Return a memory implementation based on the provided settings."""
+
+    mem_type = settings.MEMORY_TYPE
+    creator = _CREATORS.get(mem_type)
+    if creator is None:
+        available = ", ".join(sorted(_CREATORS)) or "none"
+        raise ValueError(f"Unsupported memory type '{mem_type}'. Available types: {available}")
+    return creator(settings)

--- a/tests/test_memory_factory.py
+++ b/tests/test_memory_factory.py
@@ -1,0 +1,36 @@
+import pathlib
+import sys
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+pytest.importorskip("langchain")
+
+from riskgpt.utils.memory_factory import get_memory, register_memory_backend
+from riskgpt.config.settings import RiskGPTSettings
+from langchain.memory import ConversationBufferMemory
+
+
+def test_get_memory_buffer():
+    mem = get_memory(RiskGPTSettings(MEMORY_TYPE="buffer"))
+    assert isinstance(mem, ConversationBufferMemory)
+
+
+def test_get_memory_unknown():
+    with pytest.raises(ValueError) as exc:
+        get_memory(RiskGPTSettings(MEMORY_TYPE="unknown"))
+    assert "Unsupported memory type" in str(exc.value)
+
+
+def test_register_new_backend():
+    called = {}
+
+    def creator(settings):
+        called['settings'] = settings
+        return "dummy"
+
+    register_memory_backend("dummy", creator)
+    mem = get_memory(RiskGPTSettings(MEMORY_TYPE="dummy"))
+    assert mem == "dummy"
+    assert 'settings' in called
+
+


### PR DESCRIPTION
## Summary
- implement a pluggable memory factory with registerable backends
- update memory config helper to use the new factory
- add unit tests for the memory factory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844032590f4832d98a39f2532ff6179