### PR TITLE
Implement token usage logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# RiskGPT
+
+RiskGPT provides utilities for analysing project risks using LLM based chains.
+
+```python
+from riskgpt import configure_logging
+configure_logging()
+```
+
+See the `docs/` directory for details.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,3 +12,9 @@ RiskGPT is a Python package for analyzing project-related risks and opportunitie
 ## Chains
 
 - [Get Categories](get_categories.md) – determine relevant risk categories for a project description
+
+## Logging
+
+Use `riskgpt.configure_logging()` to enable basic logging. Token usage is logged
+at the INFO level whenever a chain is executed.
+

--- a/riskgpt/__init__.py
+++ b/riskgpt/__init__.py
@@ -1,0 +1,6 @@
+"""RiskGPT package."""
+
+from .logger import configure_logging, logger
+
+__all__ = ["configure_logging", "logger"]
+

--- a/riskgpt/chains/base.py
+++ b/riskgpt/chains/base.py
@@ -6,6 +6,7 @@ from langchain_core.output_parsers import BaseOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langchain_community.callbacks import get_openai_callback
+from riskgpt.logger import logger
 
 from riskgpt.config.settings import RiskGPTSettings
 from riskgpt.utils.memory_factory import get_memory
@@ -56,4 +57,11 @@ class BaseChain:
                     prompt_name=self.prompt_name,
                     model_name=self.settings.OPENAI_MODEL_NAME,
                 )
+            logger.info(
+                "Consumed %s tokens (%.4f USD) for '%s' using %s",
+                cb.total_tokens,
+                cb.total_cost,
+                self.prompt_name or "prompt",
+                self.settings.OPENAI_MODEL_NAME,
+            )
         return result

--- a/riskgpt/logger.py
+++ b/riskgpt/logger.py
@@ -1,0 +1,37 @@
+"""Logging utilities for the RiskGPT package."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+# Package-wide logger
+logger = logging.getLogger("riskgpt")
+logger.addHandler(logging.NullHandler())
+
+
+def configure_logging(level: int = logging.INFO, handler: Optional[logging.Handler] = None) -> logging.Logger:
+    """Configure logging for RiskGPT.
+
+    Parameters
+    ----------
+    level:
+        Logging level for the RiskGPT logger. Defaults to ``logging.INFO``.
+    handler:
+        Optional custom handler. If not provided, a ``StreamHandler`` with a
+        basic format is used.
+    """
+    if handler is None:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+
+    # Avoid adding duplicate handlers when called multiple times
+    if handler not in logger.handlers:
+        logger.addHandler(handler)
+
+    logger.setLevel(level)
+    return logger
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,11 @@
+import logging
+
+from riskgpt.logger import logger, configure_logging
+
+
+def test_configure_logging_adds_handler():
+    logger.handlers.clear()
+    configure_logging(level=logging.DEBUG)
+    assert logger.level == logging.DEBUG
+    assert logger.handlers
+

--- a/tests/test_token_logging.py
+++ b/tests/test_token_logging.py
@@ -1,0 +1,49 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_community")
+
+from riskgpt.logger import configure_logging
+from riskgpt.chains.base import BaseChain
+from langchain_core.output_parsers import BaseOutputParser
+from riskgpt.models.schemas import CategoryResponse
+
+
+class DummyParser(BaseOutputParser):
+    def parse(self, text):
+        return CategoryResponse(categories=["foo"], rationale=None)
+
+    def get_format_instructions(self) -> str:
+        return ""
+
+
+def test_token_logging(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="riskgpt")
+    configure_logging(level=logging.INFO)
+
+    parser = DummyParser()
+    chain = BaseChain(prompt_template="hi", parser=parser)
+
+    def fake_invoke(inputs, memory=None):
+        return CategoryResponse(categories=["foo"], rationale=None)
+
+    class DummyCB:
+        def __enter__(self):
+            self.total_tokens = 3
+            self.total_cost = 0.001
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(chain, "chain", SimpleNamespace(invoke=fake_invoke))
+    monkeypatch.setattr("riskgpt.chains.base.get_openai_callback", lambda: DummyCB())
+
+    chain.invoke({})
+
+    assert any("Consumed" in record.getMessage() for record in caplog.records)
+


### PR DESCRIPTION
## Summary
- add `logger` module with a package logger and `configure_logging`
- expose logging utilities at the package level
- log token information for each chain invocation
- document how to enable logging
- add tests and pytest configuration for logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684409cbea8c832dab56f950de6a664a