### PR TITLE
Add risk identification chain

### DIFF
--- a/docs/get_risks.md
+++ b/docs/get_risks.md
@@ -1,0 +1,37 @@
+# Get Risks
+
+The `get_risks` chain identifies specific risks for a given risk category.
+
+## Input
+
+`RiskRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `project_description` (`str`): description of the project.
+- `category` (`str`): the risk category to analyse.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`RiskResponse`
+- `risks` (`List[Risk]`): list of identified risks with title, description and category.
+- `references` (`List[str] | None`): list of references backing the risks.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.get_risks import get_risks_chain
+from riskgpt.models.schemas import RiskRequest
+
+request = RiskRequest(
+    project_id="123",
+    project_description="An IT project to introduce a new CRM system.",
+    category="Technical",
+    domain_knowledge="The company operates in the B2B market.",
+    language="de"
+)
+
+response = get_risks_chain(request)
+print(response.risks)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ RiskGPT is a Python package for analyzing project-related risks and opportunitie
 ## Chains
 
 - [Get Categories](get_categories.md) – determine relevant risk categories for a project description
+- [Get Risks](get_risks.md) – identify risks for a specific category
 
 ## Logging
 

--- a/riskgpt/chains/__init__.py
+++ b/riskgpt/chains/__init__.py
@@ -1,8 +1,10 @@
 """Chain package initialization."""
 from .base import BaseChain  # noqa: F401
 from .get_categories import get_categories_chain  # noqa: F401
+from .get_risks import get_risks_chain  # noqa: F401
 
 __all__ = [
     "BaseChain",
     "get_categories_chain",
+    "get_risks_chain",
 ]

--- a/riskgpt/chains/get_risks.py
+++ b/riskgpt/chains/get_risks.py
@@ -1,0 +1,29 @@
+from langchain_core.output_parsers import PydanticOutputParser
+
+from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.models.schemas import RiskRequest, RiskResponse
+from riskgpt.registry.chain_registry import register
+from .base import BaseChain
+
+
+@register("get_risks")
+def get_risks_chain(request: RiskRequest) -> RiskResponse:
+    """Identify risks for a given category."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_risks")
+
+    parser = PydanticOutputParser(pydantic_object=RiskResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_risks",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return chain.invoke(inputs)

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -22,3 +22,29 @@ class CategoryResponse(BaseModel):
     categories: List[str]
     rationale: Optional[str]
     response_info: Optional[ResponseInfo] = None
+
+
+class RiskRequest(BaseModel):
+    """Input model for risk identification."""
+
+    project_id: str
+    project_description: str
+    category: str
+    domain_knowledge: Optional[str] = None
+    language: Optional[str] = "en"
+
+
+class Risk(BaseModel):
+    """Representation of a single risk."""
+
+    title: str
+    description: str
+    category: str
+
+
+class RiskResponse(BaseModel):
+    """Output model for identified risks."""
+
+    risks: List[Risk]
+    references: Optional[List[str]] = None
+    response_info: Optional[ResponseInfo] = None

--- a/riskgpt/prompts/get_risks/v1.yaml
+++ b/riskgpt/prompts/get_risks/v1.yaml
@@ -1,0 +1,14 @@
+version: "v1"
+description: "Identify risks within a category using project information."
+template: |
+  You are a risk analyst.
+  Project description: {project_description}
+  {domain_section}
+
+  Identify relevant risks in the category: {category}.
+  Each risk must have a short title and a description using the event, cause, consequence structure.
+  Support the risks with references to studies or academic papers and list the references in Harvard style.
+  Respond in the following language: {language}
+
+  {format_instructions}
+  Output the result as a JSON object that conforms to the schema above and do not include any additional text

--- a/tests/test_get_risks.py
+++ b/tests/test_get_risks.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_community")
+
+from riskgpt.chains.get_risks import get_risks_chain
+from riskgpt.models.schemas import RiskRequest
+
+
+def test_get_risks_chain():
+    request = RiskRequest(
+        project_id="123",
+        project_description="Ein neues IT-Projekt zur Einführung eines CRM-Systems.",
+        category="Technisch",
+        domain_knowledge="Das Unternehmen ist im B2B-Bereich tätig.",
+        language="de",
+    )
+    response = get_risks_chain(request)
+    assert isinstance(response.risks, list)


### PR DESCRIPTION
## Summary
- add new `get_risks` chain for listing risks in a category
- document the new chain and link from the index
- support risk request/response models
- include prompt template for risk identification
- add tests for the new chain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684412f2b850832dba355803c289c579