### PR TITLE
Fix custom backend and prompt dir handling

### DIFF
--- a/riskgpt/config/settings.py
+++ b/riskgpt/config/settings.py
@@ -7,7 +7,13 @@ class RiskGPTSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file='../.env', env_ignore_empty=True, extra='ignore')
 
-    MEMORY_TYPE: Literal["none", "buffer", "redis"] = Field(default="buffer")
+    # Allow arbitrary memory backend names so additional backends can be
+    # registered in tests and by users.  Previously this field was typed as a
+    # ``Literal`` which restricted values to ``none``, ``buffer`` or ``redis``
+    # causing validation errors when new backends were registered via
+    # ``register_memory_backend``.  Using a plain string keeps the default while
+    # permitting custom values.
+    MEMORY_TYPE: str = Field(default="buffer")
     REDIS_URL: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
     TEMPERATURE: float = Field(default=0.7, ge=0.0, le=1.0)

--- a/riskgpt/utils/prompt_loader.py
+++ b/riskgpt/utils/prompt_loader.py
@@ -6,7 +6,13 @@ from riskgpt.config.settings import RiskGPTSettings
 from riskgpt.models.schemas import Prompt
 
 
-PROMPT_DIR = Path(__file__).parent.parent / "prompts"
+# ``PROMPT_DIR`` is defined in a way that allows tests to override it using
+# ``monkeypatch`` even when the module is reloaded.  On reload the module's
+# globals are reused, therefore we only set the default value if it has not been
+# provided already.  This mirrors the behaviour of environment derived
+# configuration without hard coding the value on every reload.
+if 'PROMPT_DIR' not in globals():
+    PROMPT_DIR = Path(__file__).parent.parent / "prompts"
 
 
 def load_prompt(name: str, version: Optional[str] = None) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- allow registering new memory backends by loosening MEMORY_TYPE validation
- preserve patched PROMPT_DIR across module reloads in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441ca78668832d8dc6eca07a392dab