### PR TITLE
Add risk management chains

### DIFF
--- a/docs/check_definition.md
+++ b/docs/check_definition.md
@@ -1,0 +1,34 @@
+# Check Definition
+
+The `check_definition` chain validates and revises a risk description so that it follows the event–cause–consequence logic.
+
+## Input
+
+`DefinitionCheckRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `risk_description` (`str`): risk definition provided by the user.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`DefinitionCheckResponse`
+- `revised_description` (`str`): risk definition rewritten in the proper format.
+- `rationale` (`str | None`): explanation of the changes.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.check_definition import check_definition_chain
+from riskgpt.models.schemas import DefinitionCheckRequest
+
+request = DefinitionCheckRequest(
+    project_id="123",
+    risk_description="Systemausfall durch mangelnde Wartung kann zu Produktionsstopps führen.",
+    language="de"
+)
+
+response = check_definition_chain(request)
+print(response.revised_description)
+```

--- a/docs/get_drivers.md
+++ b/docs/get_drivers.md
@@ -1,0 +1,34 @@
+# Get Drivers
+
+The `get_drivers` chain identifies key drivers that influence a specific risk.
+
+## Input
+
+`DriverRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `risk_description` (`str`): description of the risk.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`DriverResponse`
+- `drivers` (`List[str]`): list of identified risk drivers.
+- `references` (`List[str] | None`): supporting references in Harvard style.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.get_drivers import get_drivers_chain
+from riskgpt.models.schemas import DriverRequest
+
+request = DriverRequest(
+    project_id="123",
+    risk_description="Systemausfall durch mangelnde Wartung kann zu Produktionsstopps führen.",
+    language="de"
+)
+
+response = get_drivers_chain(request)
+print(response.drivers)
+```

--- a/docs/get_impact.md
+++ b/docs/get_impact.md
@@ -1,0 +1,37 @@
+# Get Impact
+
+The `get_impact` chain estimates the potential impact of a risk using a three-point estimate and suggests a probability distribution.
+
+## Input
+
+`ImpactRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `risk_description` (`str`): description of the risk.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`ImpactResponse`
+- `minimum` (`float`): lower bound of the impact estimate.
+- `most_likely` (`float`): most likely impact value.
+- `maximum` (`float`): upper bound of the impact estimate.
+- `distribution` (`str`): suggested probability distribution.
+- `references` (`List[str] | None`): supporting references.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.get_impact import get_impact_chain
+from riskgpt.models.schemas import ImpactRequest
+
+request = ImpactRequest(
+    project_id="123",
+    risk_description="Systemausfall durch mangelnde Wartung kann zu Produktionsstopps führen.",
+    language="de"
+)
+
+response = get_impact_chain(request)
+print(response.most_likely)
+```

--- a/docs/get_mitigations.md
+++ b/docs/get_mitigations.md
@@ -1,0 +1,36 @@
+# Get Mitigations
+
+The `get_mitigations` chain suggests mitigation measures for a risk based on its drivers.
+
+## Input
+
+`MitigationRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `risk_description` (`str`): description of the risk.
+- `drivers` (`List[str]`, optional): identified drivers for this risk.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`MitigationResponse`
+- `mitigations` (`List[str]`): proposed mitigation measures.
+- `references` (`List[str] | None`): supporting references.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.get_mitigations import get_mitigations_chain
+from riskgpt.models.schemas import MitigationRequest
+
+request = MitigationRequest(
+    project_id="123",
+    risk_description="Systemausfall durch mangelnde Wartung kann zu Produktionsstopps führen.",
+    drivers=["veraltete Hardware"],
+    language="de"
+)
+
+response = get_mitigations_chain(request)
+print(response.mitigations)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,10 @@ nav:
   - Home: index.md
   - Chains:
       - Get Categories: get_categories.md
+      - Check Definition: check_definition.md
+      - Get Drivers: get_drivers.md
+      - Get Impact: get_impact.md
+      - Get Mitigations: get_mitigations.md
 markdown_extensions:
   - toc:
       permalink: true

--- a/riskgpt/chains/__init__.py
+++ b/riskgpt/chains/__init__.py
@@ -2,9 +2,17 @@
 from .base import BaseChain  # noqa: F401
 from .get_categories import get_categories_chain  # noqa: F401
 from .get_risks import get_risks_chain  # noqa: F401
+from .check_definition import check_definition_chain  # noqa: F401
+from .get_drivers import get_drivers_chain  # noqa: F401
+from .get_impact import get_impact_chain  # noqa: F401
+from .get_mitigations import get_mitigations_chain  # noqa: F401
 
 __all__ = [
     "BaseChain",
     "get_categories_chain",
     "get_risks_chain",
+    "check_definition_chain",
+    "get_drivers_chain",
+    "get_impact_chain",
+    "get_mitigations_chain",
 ]

--- a/riskgpt/chains/check_definition.py
+++ b/riskgpt/chains/check_definition.py
@@ -1,0 +1,28 @@
+from langchain_core.output_parsers import PydanticOutputParser
+
+from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.models.schemas import DefinitionCheckRequest, DefinitionCheckResponse
+from riskgpt.registry.chain_registry import register
+from .base import BaseChain
+
+
+@register("check_definition")
+def check_definition_chain(request: DefinitionCheckRequest) -> DefinitionCheckResponse:
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("check_definition")
+
+    parser = PydanticOutputParser(pydantic_object=DefinitionCheckResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="check_definition",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return chain.invoke(inputs)

--- a/riskgpt/chains/get_drivers.py
+++ b/riskgpt/chains/get_drivers.py
@@ -1,0 +1,28 @@
+from langchain_core.output_parsers import PydanticOutputParser
+
+from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.models.schemas import DriverRequest, DriverResponse
+from riskgpt.registry.chain_registry import register
+from .base import BaseChain
+
+
+@register("get_drivers")
+def get_drivers_chain(request: DriverRequest) -> DriverResponse:
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_drivers")
+
+    parser = PydanticOutputParser(pydantic_object=DriverResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_drivers",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return chain.invoke(inputs)

--- a/riskgpt/chains/get_impact.py
+++ b/riskgpt/chains/get_impact.py
@@ -1,0 +1,28 @@
+from langchain_core.output_parsers import PydanticOutputParser
+
+from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.models.schemas import ImpactRequest, ImpactResponse
+from riskgpt.registry.chain_registry import register
+from .base import BaseChain
+
+
+@register("get_impact")
+def get_impact_chain(request: ImpactRequest) -> ImpactResponse:
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_impact")
+
+    parser = PydanticOutputParser(pydantic_object=ImpactResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_impact",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return chain.invoke(inputs)

--- a/riskgpt/config/settings.py
+++ b/riskgpt/config/settings.py
@@ -1,22 +1,26 @@
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing import Literal, Optional
+from typing import Optional
+from pydantic import field_validator
 
 
 class RiskGPTSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file='../.env', env_ignore_empty=True, extra='ignore')
 
-    # Allow arbitrary memory backend names so additional backends can be
-    # registered in tests and by users.  Previously this field was typed as a
-    # ``Literal`` which restricted values to ``none``, ``buffer`` or ``redis``
-    # causing validation errors when new backends were registered via
-    # ``register_memory_backend``.  Using a plain string keeps the default while
-    # permitting custom values.
     MEMORY_TYPE: str = Field(default="buffer")
     REDIS_URL: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
     TEMPERATURE: float = Field(default=0.7, ge=0.0, le=1.0)
     OPENAI_MODEL_NAME: str = Field(default="gpt-4.1-mini")
     DEFAULT_PROMPT_VERSION: str = Field(default="v1")
+
+    @field_validator("MEMORY_TYPE")
+    @classmethod
+    def validate_memory_type(cls, v: str) -> str:
+        from riskgpt.utils.memory_factory import _CREATORS
+        allowed = {"none", "buffer", "redis"}.union(_CREATORS.keys())
+        if v not in allowed:
+            raise ValueError("Input should be 'none', 'buffer' or 'redis'")
+        return v
 

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -48,3 +48,75 @@ class RiskResponse(BaseModel):
     risks: List[Risk]
     references: Optional[List[str]] = None
     response_info: Optional[ResponseInfo] = None
+
+
+class DefinitionCheckRequest(BaseModel):
+    """Input model for checking and revising a risk definition."""
+
+    project_id: str
+    risk_description: str
+    domain_knowledge: Optional[str] = None
+    language: Optional[str] = "en"
+
+
+class DefinitionCheckResponse(BaseModel):
+    """Output model for a revised risk definition."""
+
+    revised_description: str
+    rationale: Optional[str] = None
+    response_info: Optional[ResponseInfo] = None
+
+
+class DriverRequest(BaseModel):
+    """Input model for risk driver identification."""
+
+    project_id: str
+    risk_description: str
+    domain_knowledge: Optional[str] = None
+    language: Optional[str] = "en"
+
+
+class DriverResponse(BaseModel):
+    """Output model containing risk drivers."""
+
+    drivers: List[str]
+    references: Optional[List[str]] = None
+    response_info: Optional[ResponseInfo] = None
+
+
+class ImpactRequest(BaseModel):
+    """Input model for estimating risk impact."""
+
+    project_id: str
+    risk_description: str
+    domain_knowledge: Optional[str] = None
+    language: Optional[str] = "en"
+
+
+class ImpactResponse(BaseModel):
+    """Output model for a three-point impact estimate."""
+
+    minimum: float
+    most_likely: float
+    maximum: float
+    distribution: str
+    references: Optional[List[str]] = None
+    response_info: Optional[ResponseInfo] = None
+
+
+class MitigationRequest(BaseModel):
+    """Input model for risk mitigation measures."""
+
+    project_id: str
+    risk_description: str
+    drivers: Optional[List[str]] = None
+    domain_knowledge: Optional[str] = None
+    language: Optional[str] = "en"
+
+
+class MitigationResponse(BaseModel):
+    """Output model containing mitigation measures."""
+
+    mitigations: List[str]
+    references: Optional[List[str]] = None
+    response_info: Optional[ResponseInfo] = None

--- a/riskgpt/prompts/check_definition/v1.yaml
+++ b/riskgpt/prompts/check_definition/v1.yaml
@@ -1,0 +1,13 @@
+version: "v1"
+description: "Check and revise a risk definition using the event-cause-consequence structure."
+template: |
+  You are a risk analyst.
+  Provided risk definition: {risk_description}
+  {domain_section}
+
+  Evaluate whether the definition follows the event, cause, consequence logic.
+  Rewrite it if necessary so that it clearly states the event, its cause and the consequence.
+  Respond in the following language: {language}
+
+  {format_instructions}
+  Output the result as a JSON object that conforms to the schema above and do not include any additional text

--- a/riskgpt/prompts/get_drivers/v1.yaml
+++ b/riskgpt/prompts/get_drivers/v1.yaml
@@ -1,0 +1,13 @@
+version: "v1"
+description: "Identify key risk drivers for a given risk."
+template: |
+  You are a risk analyst.
+  Risk description: {risk_description}
+  {domain_section}
+
+  List the main drivers that could increase the likelihood or impact of this risk.
+  Support your answer with references to studies or academic papers in Harvard style.
+  Respond in the following language: {language}
+
+  {format_instructions}
+  Output the result as a JSON object that conforms to the schema above and do not include any additional text

--- a/riskgpt/prompts/get_impact/v1.yaml
+++ b/riskgpt/prompts/get_impact/v1.yaml
@@ -1,0 +1,13 @@
+version: "v1"
+description: "Estimate the impact of a risk using a three-point estimate."
+template: |
+  You are a risk analyst.
+  Risk description: {risk_description}
+  {domain_section}
+
+  Provide a three-point estimate (minimum, most likely, maximum) for the impact of this risk and suggest an appropriate probability distribution.
+  Back up your reasoning with references in Harvard style where applicable.
+  Respond in the following language: {language}
+
+  {format_instructions}
+  Output the result as a JSON object that conforms to the schema above and do not include any additional text

--- a/riskgpt/prompts/get_mitigations/v1.yaml
+++ b/riskgpt/prompts/get_mitigations/v1.yaml
@@ -1,0 +1,14 @@
+version: "v1"
+description: "Suggest mitigation measures based on identified risk drivers."
+template: |
+  You are a risk analyst.
+  Risk description: {risk_description}
+  {drivers_section}
+  {domain_section}
+
+  Propose mitigation measures addressing the identified drivers.
+  Provide references in Harvard style where useful.
+  Respond in the following language: {language}
+
+  {format_instructions}
+  Output the result as a JSON object that conforms to the schema above and do not include any additional text


### PR DESCRIPTION
## Summary
- add new chains for risk definition checking, drivers, impact, and mitigations
- provide prompts and documentation for the new chains
- extend BaseChain with offline fallback for tests
- validate memory types via pydantic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441f51df68832dbf6700fd4915eb05