### PR TITLE
Add reusable system prompt support

### DIFF
--- a/riskgpt/chains/get_risks.py
+++ b/riskgpt/chains/get_risks.py
@@ -1,6 +1,6 @@
 from langchain_core.output_parsers import PydanticOutputParser
 
-from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.utils.prompt_loader import load_prompt, load_system_prompt
 from riskgpt.config.settings import RiskGPTSettings
 from riskgpt.models.schemas import RiskRequest, RiskResponse
 from riskgpt.registry.chain_registry import register
@@ -11,6 +11,7 @@ from .base import BaseChain
 def get_risks_chain(request: RiskRequest) -> RiskResponse:
     settings = RiskGPTSettings()
     prompt_data = load_prompt("get_risks")
+    system_prompt = load_system_prompt()
 
     parser = PydanticOutputParser(pydantic_object=RiskResponse)
     chain = BaseChain(
@@ -24,5 +25,6 @@ def get_risks_chain(request: RiskRequest) -> RiskResponse:
     inputs["domain_section"] = (
         f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
     )
+    inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)

--- a/riskgpt/prompts/get_risks/v1.yaml
+++ b/riskgpt/prompts/get_risks/v1.yaml
@@ -1,7 +1,7 @@
 version: "v1"
 description: "Identify risks within a category using project information."
 template: |
-  You are a risk analyst.
+  {system_prompt}
   Project description: {project_description}
   {domain_section}
 

--- a/riskgpt/prompts/system/v1.yaml
+++ b/riskgpt/prompts/system/v1.yaml
@@ -1,0 +1,11 @@
+version: "v1"
+description: "Reusable system prompt for risk analysis"
+template: |
+  You are a meticulous risk analyst writing for senior financial professionals.
+  • Use clear, formal UK-English.
+  • Never invent bibliographic references.
+    – Cite only if you recall a **real** academic or industry source that you are ≥90 % sure exists.
+    – Each citation **must** include either a DOI or a stable URL.
+    – If no suitable reference exists, omit the reference field altogether for that risk.
+  • Keep each risk title ≤ 12 words.
+  • Follow the output JSON schema exactly; return **no additional text**.

--- a/riskgpt/utils/prompt_loader.py
+++ b/riskgpt/utils/prompt_loader.py
@@ -27,3 +27,9 @@ def load_prompt(name: str, version: Optional[str] = None) -> Dict[str, Any]:
     prompt = Prompt(**data)
     return prompt.model_dump()
 
+
+def load_system_prompt(version: Optional[str] = None) -> str:
+    """Return the system prompt text for reuse across chains."""
+    data = load_prompt("system", version)
+    return data["template"]
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,13 @@ def test_load_prompt(monkeypatch):
     assert "You are a risk analyst." in data["template"]
 
 
+def test_load_system_prompt(monkeypatch):
+    from riskgpt.utils import prompt_loader
+
+    monkeypatch.setattr(prompt_loader, "load_prompt", lambda name, version=None: {"template": "sys"})
+    assert prompt_loader.load_system_prompt() == "sys"
+
+
 def test_load_prompt_default_version(monkeypatch, tmp_path):
     prompts_dir = tmp_path / "prompts" / "foo"
     prompts_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- introduce a shared system prompt in `prompts/system/v1.yaml`
- include the system prompt placeholder in the `get_risks` prompt
- extend prompt loader with `load_system_prompt`
- pass the system prompt into the `get_risks` chain
- unit test coverage for loading the system prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6844244457f4832d89e339d759b1e2e1