### PR TITLE
Add Jupyter playground notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ configure_logging()
 
 See the `docs/` directory for details.
 
+An example Jupyter notebook is available in `notebooks/playground.ipynb` for an
+interactive playground.
+

--- a/notebooks/playground.ipynb
+++ b/notebooks/playground.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RiskGPT Playground\n",
+    "This notebook demonstrates basic usage of the `riskgpt` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from riskgpt import configure_logging\n",
+    "configure_logging()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from riskgpt.chains import get_categories_chain\n",
+    "from riskgpt.models.schemas import CategoryRequest\n",
+    "\n",
+    "request = CategoryRequest(\n",
+    "    project_id=\"demo\",\n",
+    "    project_description=\"An IT project to introduce a new CRM system.\",\n",
+    "    domain_knowledge=\"The company operates in the B2B market.\",\n",
+    "    language=\"en\"\n",
+    ")\n",
+    "\n",
+    "response = get_categories_chain(request)\n",
+    "print(response)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a minimal Jupyter notebook for experimenting with RiskGPT
- mention the notebook in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684425674840832d8dac4285b3189de5