### PR TITLE
Implement risk assessment chain

### DIFF
--- a/docs/get_assessment.md
+++ b/docs/get_assessment.md
@@ -1,0 +1,40 @@
+# Get Assessment
+
+The `get_assessment` chain evaluates the potential impact of a risk. It either returns a three-point estimate with a probability distribution or, for single-event risks, an impact and probability.
+
+## Input
+
+`AssessmentRequest`
+- `project_id` (`str`): unique identifier of the project.
+- `risk_description` (`str`): description of the risk.
+- `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`AssessmentResponse`
+- `minimum` (`float | None`): lower bound of the impact estimate.
+- `most_likely` (`float | None`): most likely impact value.
+- `maximum` (`float | None`): upper bound of the impact estimate.
+- `distribution` (`str | None`): suggested probability distribution.
+- `impact` (`float | None`): impact value for single events.
+- `probability` (`float | None`): probability of occurrence for single events.
+- `evidence` (`str | None`): explanation of the assessment and supporting rationale.
+- `references` (`List[str] | None`): supporting references.
+- `response_info` (`ResponseInfo | None`): meta-information including token usage.
+
+## Example
+
+```python
+from riskgpt.chains.get_assessment import get_assessment_chain
+from riskgpt.models.schemas import AssessmentRequest
+
+request = AssessmentRequest(
+    project_id="123",
+    risk_description="Systemausfall durch mangelnde Wartung kann zu Produktionsstopps führen.",
+    language="de"
+)
+
+response = get_assessment_chain(request)
+print(response.evidence)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,14 @@ RiskGPT is a Python package for analyzing project-related risks and opportunitie
 
 - Extract risk categories from project descriptions
 - Identify specific risks per category
-- Estimate impact using probabilistic methods
+- Assess impact using distributions or probability estimates with supporting evidence
 - Support for domain-specific context and memory
 
 ## Chains
 
 - [Get Categories](get_categories.md) – determine relevant risk categories for a project description
 - [Get Risks](get_risks.md) – identify risks for a specific category
+- [Get Assessment](get_assessment.md) – estimate impact and probability of a risk
 
 ## Logging
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ nav:
       - Get Categories: get_categories.md
       - Check Definition: check_definition.md
       - Get Drivers: get_drivers.md
-      - Get Impact: get_impact.md
+      - Get Assessment: get_assessment.md
       - Get Mitigations: get_mitigations.md
 markdown_extensions:
   - toc:

--- a/riskgpt/chains/__init__.py
+++ b/riskgpt/chains/__init__.py
@@ -4,7 +4,7 @@ from .get_categories import get_categories_chain  # noqa: F401
 from .get_risks import get_risks_chain  # noqa: F401
 from .check_definition import check_definition_chain  # noqa: F401
 from .get_drivers import get_drivers_chain  # noqa: F401
-from .get_impact import get_impact_chain  # noqa: F401
+from .get_assessment import get_assessment_chain  # noqa: F401
 from .get_mitigations import get_mitigations_chain  # noqa: F401
 
 __all__ = [
@@ -13,6 +13,6 @@ __all__ = [
     "get_risks_chain",
     "check_definition_chain",
     "get_drivers_chain",
-    "get_impact_chain",
+    "get_assessment_chain",
     "get_mitigations_chain",
 ]

--- a/riskgpt/chains/get_assessment.py
+++ b/riskgpt/chains/get_assessment.py
@@ -1,0 +1,28 @@
+from langchain_core.output_parsers import PydanticOutputParser
+
+from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.config.settings import RiskGPTSettings
+from riskgpt.models.schemas import AssessmentRequest, AssessmentResponse
+from riskgpt.registry.chain_registry import register
+from .base import BaseChain
+
+
+@register("get_assessment")
+def get_assessment_chain(request: AssessmentRequest) -> AssessmentResponse:
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_assessment")
+
+    parser = PydanticOutputParser(pydantic_object=AssessmentResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_assessment",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return chain.invoke(inputs)

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -104,6 +104,29 @@ class ImpactResponse(BaseModel):
     response_info: Optional[ResponseInfo] = None
 
 
+class AssessmentRequest(BaseModel):
+    """Input model for assessing a risk's impact."""
+
+    project_id: str
+    risk_description: str
+    domain_knowledge: Optional[str] = None
+    language: Optional[str] = "en"
+
+
+class AssessmentResponse(BaseModel):
+    """Output model for a risk impact assessment."""
+
+    minimum: Optional[float] = None
+    most_likely: Optional[float] = None
+    maximum: Optional[float] = None
+    distribution: Optional[str] = None
+    impact: Optional[float] = None
+    probability: Optional[float] = None
+    evidence: Optional[str] = None
+    references: Optional[List[str]] = None
+    response_info: Optional[ResponseInfo] = None
+
+
 class MitigationRequest(BaseModel):
     """Input model for risk mitigation measures."""
 

--- a/riskgpt/prompts/get_assessment/v1.yaml
+++ b/riskgpt/prompts/get_assessment/v1.yaml
@@ -1,0 +1,16 @@
+version: "v1"
+description: "Assess the impact and probability of a risk."
+template: |
+  You are a risk analyst.
+  Risk description: {risk_description}
+  {domain_section}
+
+  Determine whether this risk is a single event or not.
+  - If it is not a single event, provide a three-point estimate (minimum, most likely, maximum) for its impact and specify an appropriate probability distribution.
+  - If it is a single event, provide an impact estimate and the probability of occurrence.
+
+  Explain why you assessed the risk in this way and how you derived the values. Include references in Harvard style when possible.
+  Respond in the following language: {language}
+
+  {format_instructions}
+  Output the result as a JSON object that conforms to the schema above and do not include any additional text.

--- a/tests/test_get_assessment.py
+++ b/tests/test_get_assessment.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_community")
+
+from riskgpt.chains.get_assessment import get_assessment_chain
+from riskgpt.models.schemas import AssessmentRequest
+
+
+def test_get_assessment_chain():
+    request = AssessmentRequest(
+        project_id="123",
+        risk_description="Ein Systemausfall kann zu Produktionsstopps f\u00fchren.",
+        language="de",
+    )
+    response = get_assessment_chain(request)
+    assert hasattr(response, "evidence")
+


### PR DESCRIPTION
## Summary
- add new `get_assessment` chain and prompt
- allow assessing single events with impact & probability
- document assessment chain and update docs navigation
- expose the chain in package init and add simple test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684429229540832d8a6edfd469683773