### PR TITLE
Ensure system prompt used when evidence requested

### DIFF
--- a/docs/get_drivers.md
+++ b/docs/get_drivers.md
@@ -1,6 +1,8 @@
 # Get Drivers
 
 The `get_drivers` chain identifies key drivers that influence a specific risk.
+It uses the shared system prompt so that any cited evidence should only
+reference sources the model is confident actually exist.
 
 ## Input
 

--- a/docs/get_mitigations.md
+++ b/docs/get_mitigations.md
@@ -1,6 +1,8 @@
 # Get Mitigations
 
 The `get_mitigations` chain suggests mitigation measures for a risk based on its drivers.
+It also includes the system prompt so that references are only given when the model
+is reasonably sure of a real source.
 
 ## Input
 

--- a/riskgpt/chains/get_drivers.py
+++ b/riskgpt/chains/get_drivers.py
@@ -1,6 +1,6 @@
 from langchain_core.output_parsers import PydanticOutputParser
 
-from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.utils.prompt_loader import load_prompt, load_system_prompt
 from riskgpt.config.settings import RiskGPTSettings
 from riskgpt.models.schemas import DriverRequest, DriverResponse
 from riskgpt.registry.chain_registry import register
@@ -11,6 +11,7 @@ from .base import BaseChain
 def get_drivers_chain(request: DriverRequest) -> DriverResponse:
     settings = RiskGPTSettings()
     prompt_data = load_prompt("get_drivers")
+    system_prompt = load_system_prompt()
 
     parser = PydanticOutputParser(pydantic_object=DriverResponse)
     chain = BaseChain(
@@ -24,5 +25,6 @@ def get_drivers_chain(request: DriverRequest) -> DriverResponse:
     inputs["domain_section"] = (
         f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
     )
+    inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)

--- a/riskgpt/chains/get_mitigations.py
+++ b/riskgpt/chains/get_mitigations.py
@@ -1,6 +1,6 @@
 from langchain_core.output_parsers import PydanticOutputParser
 
-from riskgpt.utils.prompt_loader import load_prompt
+from riskgpt.utils.prompt_loader import load_prompt, load_system_prompt
 from riskgpt.config.settings import RiskGPTSettings
 from riskgpt.models.schemas import MitigationRequest, MitigationResponse
 from riskgpt.registry.chain_registry import register
@@ -11,6 +11,7 @@ from .base import BaseChain
 def get_mitigations_chain(request: MitigationRequest) -> MitigationResponse:
     settings = RiskGPTSettings()
     prompt_data = load_prompt("get_mitigations")
+    system_prompt = load_system_prompt()
 
     parser = PydanticOutputParser(pydantic_object=MitigationResponse)
     chain = BaseChain(
@@ -27,5 +28,6 @@ def get_mitigations_chain(request: MitigationRequest) -> MitigationResponse:
     inputs["drivers_section"] = (
         f"Identified risk drivers: {', '.join(request.drivers)}" if request.drivers else ""
     )
+    inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)

--- a/riskgpt/prompts/get_drivers/v1.yaml
+++ b/riskgpt/prompts/get_drivers/v1.yaml
@@ -1,7 +1,8 @@
 version: "v1"
 description: "Identify key risk drivers for a given risk."
+
 template: |
-  You are a risk analyst.
+  {system_prompt}
   Risk description: {risk_description}
   {domain_section}
 

--- a/riskgpt/prompts/get_mitigations/v1.yaml
+++ b/riskgpt/prompts/get_mitigations/v1.yaml
@@ -1,7 +1,7 @@
 version: "v1"
 description: "Suggest mitigation measures based on identified risk drivers."
 template: |
-  You are a risk analyst.
+  {system_prompt}
   Risk description: {risk_description}
   {drivers_section}
   {domain_section}


### PR DESCRIPTION
## Summary
- include system prompt placeholder in driver and mitigation prompts
- load the system prompt in `get_drivers_chain` and `get_mitigations_chain`
- document that these chains use the shared system prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68442ec57554832d9211842210d4e2ab