### PR TITLE
Add mitigation chain test

### DIFF
--- a/tests/test_get_mitigations.py
+++ b/tests/test_get_mitigations.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_community")
+
+from riskgpt.chains.get_mitigations import get_mitigations_chain
+from riskgpt.models.schemas import MitigationRequest
+
+
+def test_get_mitigations_chain():
+    request = MitigationRequest(
+        project_id="123",
+        risk_description="Ein Systemausfall kann zu Produktionsstopps führen.",
+        drivers=["veraltete Hardware"],
+        domain_knowledge="Das Unternehmen ist im B2B-Bereich tätig.",
+        language="de",
+    )
+    response = get_mitigations_chain(request)
+    assert isinstance(response.mitigations, list)


### PR DESCRIPTION
## Summary
- test mitigation generation similar to existing risk and category tests

## Testing
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684432c82d3c832d9ccf04d4c56deb37