### PR TITLE
Add async chain support

### DIFF
--- a/riskgpt/chains/__init__.py
+++ b/riskgpt/chains/__init__.py
@@ -1,16 +1,25 @@
 """Chain package initialization."""
 from .base import BaseChain  # noqa: F401
-from .get_categories import get_categories_chain  # noqa: F401
-from .get_risks import get_risks_chain  # noqa: F401
-from .check_definition import check_definition_chain  # noqa: F401
-from .get_drivers import get_drivers_chain  # noqa: F401
-from .get_assessment import get_assessment_chain  # noqa: F401
-from .get_mitigations import get_mitigations_chain  # noqa: F401
-from .prioritize_risks import prioritize_risks_chain  # noqa: F401
-from .cost_benefit import cost_benefit_chain  # noqa: F401
-from .get_monitoring import get_monitoring_chain  # noqa: F401
-from .get_opportunities import get_opportunities_chain  # noqa: F401
-from .communicate_risks import communicate_risks_chain  # noqa: F401
+from .get_categories import (
+    get_categories_chain,
+    async_get_categories_chain,
+)  # noqa: F401
+from .get_risks import get_risks_chain, async_get_risks_chain  # noqa: F401
+from .check_definition import (
+    check_definition_chain,
+    async_check_definition_chain,
+)  # noqa: F401
+from .get_drivers import get_drivers_chain, async_get_drivers_chain  # noqa: F401
+from .get_assessment import get_assessment_chain, async_get_assessment_chain  # noqa: F401
+from .get_mitigations import get_mitigations_chain, async_get_mitigations_chain  # noqa: F401
+from .prioritize_risks import (
+    prioritize_risks_chain,
+    async_prioritize_risks_chain,
+)  # noqa: F401
+from .cost_benefit import cost_benefit_chain, async_cost_benefit_chain  # noqa: F401
+from .get_monitoring import get_monitoring_chain, async_get_monitoring_chain  # noqa: F401
+from .get_opportunities import get_opportunities_chain, async_get_opportunities_chain  # noqa: F401
+from .communicate_risks import communicate_risks_chain, async_communicate_risks_chain  # noqa: F401
 
 __all__ = [
     "BaseChain",
@@ -25,4 +34,15 @@ __all__ = [
     "get_monitoring_chain",
     "get_opportunities_chain",
     "communicate_risks_chain",
+    "async_get_categories_chain",
+    "async_get_risks_chain",
+    "async_check_definition_chain",
+    "async_get_drivers_chain",
+    "async_get_assessment_chain",
+    "async_get_mitigations_chain",
+    "async_prioritize_risks_chain",
+    "async_cost_benefit_chain",
+    "async_get_monitoring_chain",
+    "async_get_opportunities_chain",
+    "async_communicate_risks_chain",
 ]

--- a/riskgpt/chains/base.py
+++ b/riskgpt/chains/base.py
@@ -82,3 +82,23 @@ class BaseChain:
                 self.settings.OPENAI_MODEL_NAME,
             )
         return result
+
+    async def invoke_async(self, inputs: Dict[str, Any]):
+        """Asynchronously invoke the underlying chain."""
+        with get_openai_callback() as cb:
+            result = await self.chain.ainvoke(inputs, memory=self.memory)
+            if hasattr(result, "response_info"):
+                result.response_info = ResponseInfo(
+                    consumed_tokens=cb.total_tokens,
+                    total_cost=cb.total_cost,
+                    prompt_name=self.prompt_name,
+                    model_name=self.settings.OPENAI_MODEL_NAME,
+                )
+            logger.info(
+                "Consumed %s tokens (%.4f USD) for '%s' using %s",
+                cb.total_tokens,
+                cb.total_cost,
+                self.prompt_name or "prompt",
+                self.settings.OPENAI_MODEL_NAME,
+            )
+        return result

--- a/riskgpt/chains/check_definition.py
+++ b/riskgpt/chains/check_definition.py
@@ -26,3 +26,26 @@ def check_definition_chain(request: DefinitionCheckRequest) -> DefinitionCheckRe
     )
 
     return chain.invoke(inputs)
+
+
+async def async_check_definition_chain(
+    request: DefinitionCheckRequest,
+) -> DefinitionCheckResponse:
+    """Asynchronous wrapper around :func:`check_definition_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("check_definition")
+
+    parser = PydanticOutputParser(pydantic_object=DefinitionCheckResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="check_definition",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/communicate_risks.py
+++ b/riskgpt/chains/communicate_risks.py
@@ -28,3 +28,28 @@ def communicate_risks_chain(request: CommunicationRequest) -> CommunicationRespo
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_communicate_risks_chain(
+    request: CommunicationRequest,
+) -> CommunicationResponse:
+    """Asynchronous wrapper around :func:`communicate_risks_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("communicate_risks")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=CommunicationResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="communicate_risks",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/cost_benefit.py
+++ b/riskgpt/chains/cost_benefit.py
@@ -29,3 +29,27 @@ def cost_benefit_chain(request: CostBenefitRequest) -> CostBenefitResponse:
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_cost_benefit_chain(request: CostBenefitRequest) -> CostBenefitResponse:
+    """Asynchronous wrapper around :func:`cost_benefit_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("cost_benefit")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=CostBenefitResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="cost_benefit",
+    )
+
+    inputs = request.model_dump()
+    inputs["mitigations"] = ", ".join(request.mitigations)
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_assessment.py
+++ b/riskgpt/chains/get_assessment.py
@@ -28,3 +28,26 @@ def get_assessment_chain(request: AssessmentRequest) -> AssessmentResponse:
 
     inputs["system_prompt"] = system_prompt
     return chain.invoke(inputs)
+
+
+async def async_get_assessment_chain(request: AssessmentRequest) -> AssessmentResponse:
+    """Asynchronous wrapper around :func:`get_assessment_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_assessment")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=AssessmentResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_assessment",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    inputs["system_prompt"] = system_prompt
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_categories.py
+++ b/riskgpt/chains/get_categories.py
@@ -26,3 +26,24 @@ def get_categories_chain(request: CategoryRequest) -> CategoryResponse:
     )
 
     return chain.invoke(inputs)
+
+
+async def async_get_categories_chain(request: CategoryRequest) -> CategoryResponse:
+    """Asynchronous wrapper around :func:`get_categories_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_categories")
+
+    parser = PydanticOutputParser(pydantic_object=CategoryResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_categories",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_drivers.py
+++ b/riskgpt/chains/get_drivers.py
@@ -28,3 +28,26 @@ def get_drivers_chain(request: DriverRequest) -> DriverResponse:
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_get_drivers_chain(request: DriverRequest) -> DriverResponse:
+    """Asynchronous wrapper around :func:`get_drivers_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_drivers")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=DriverResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_drivers",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_mitigations.py
+++ b/riskgpt/chains/get_mitigations.py
@@ -31,3 +31,29 @@ def get_mitigations_chain(request: MitigationRequest) -> MitigationResponse:
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_get_mitigations_chain(request: MitigationRequest) -> MitigationResponse:
+    """Asynchronous wrapper around :func:`get_mitigations_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_mitigations")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=MitigationResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_mitigations",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["drivers_section"] = (
+        f"Identified risk drivers: {', '.join(request.drivers)}" if request.drivers else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_monitoring.py
+++ b/riskgpt/chains/get_monitoring.py
@@ -28,3 +28,26 @@ def get_monitoring_chain(request: MonitoringRequest) -> MonitoringResponse:
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_get_monitoring_chain(request: MonitoringRequest) -> MonitoringResponse:
+    """Asynchronous wrapper around :func:`get_monitoring_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_monitoring")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=MonitoringResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_monitoring",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_opportunities.py
+++ b/riskgpt/chains/get_opportunities.py
@@ -29,3 +29,27 @@ def get_opportunities_chain(request: OpportunityRequest) -> OpportunityResponse:
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_get_opportunities_chain(request: OpportunityRequest) -> OpportunityResponse:
+    """Asynchronous wrapper around :func:`get_opportunities_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_opportunities")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=OpportunityResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_opportunities",
+    )
+
+    inputs = request.model_dump()
+    inputs["risks"] = ", ".join(request.risks)
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/get_risks.py
+++ b/riskgpt/chains/get_risks.py
@@ -28,3 +28,26 @@ def get_risks_chain(request: RiskRequest) -> RiskResponse:
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_get_risks_chain(request: RiskRequest) -> RiskResponse:
+    """Asynchronous wrapper around :func:`get_risks_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("get_risks")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=RiskResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="get_risks",
+    )
+
+    inputs = request.model_dump()
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/riskgpt/chains/prioritize_risks.py
+++ b/riskgpt/chains/prioritize_risks.py
@@ -29,3 +29,29 @@ def prioritize_risks_chain(request: PrioritizationRequest) -> PrioritizationResp
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
+
+
+async def async_prioritize_risks_chain(
+    request: PrioritizationRequest,
+) -> PrioritizationResponse:
+    """Asynchronous wrapper around :func:`prioritize_risks_chain`."""
+    settings = RiskGPTSettings()
+    prompt_data = load_prompt("prioritize_risks")
+    system_prompt = load_system_prompt()
+
+    parser = PydanticOutputParser(pydantic_object=PrioritizationResponse)
+    chain = BaseChain(
+        prompt_template=prompt_data["template"],
+        parser=parser,
+        settings=settings,
+        prompt_name="prioritize_risks",
+    )
+
+    inputs = request.model_dump()
+    inputs["risks"] = ", ".join(request.risks)
+    inputs["domain_section"] = (
+        f"Domain knowledge: {request.domain_knowledge}" if request.domain_knowledge else ""
+    )
+    inputs["system_prompt"] = system_prompt
+
+    return await chain.invoke_async(inputs)

--- a/tests/test_async_base_chain.py
+++ b/tests/test_async_base_chain.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+import asyncio
+import logging
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_community")
+
+from riskgpt.logger import configure_logging
+from riskgpt.chains.base import BaseChain
+from langchain_core.output_parsers import BaseOutputParser
+from riskgpt.models.schemas import CategoryResponse
+
+
+class DummyParser(BaseOutputParser):
+    def parse(self, text):
+        return CategoryResponse(categories=["foo"], rationale=None)
+
+    def get_format_instructions(self) -> str:
+        return ""
+
+
+def test_async_invoke(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="riskgpt")
+    configure_logging(level=logging.INFO)
+
+    parser = DummyParser()
+    chain = BaseChain(prompt_template="hi", parser=parser)
+
+    async def fake_ainvoke(inputs, memory=None):
+        return CategoryResponse(categories=["foo"], rationale=None)
+
+    class DummyCB:
+        def __enter__(self):
+            self.total_tokens = 3
+            self.total_cost = 0.001
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(chain, "chain", SimpleNamespace(ainvoke=fake_ainvoke))
+    monkeypatch.setattr("riskgpt.chains.base.get_openai_callback", lambda: DummyCB())
+
+    asyncio.run(chain.invoke_async({}))
+
+    assert any("Consumed" in record.getMessage() for record in caplog.records)
+

--- a/tests/test_async_chains.py
+++ b/tests/test_async_chains.py
@@ -1,0 +1,21 @@
+import asyncio
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+pytest.importorskip("langchain_community")
+
+from riskgpt.chains.get_categories import async_get_categories_chain
+from riskgpt.models.schemas import CategoryRequest
+
+
+def test_async_get_categories_chain():
+    request = CategoryRequest(
+        project_id="123",
+        project_description="Ein neues IT-Projekt zur Einführung eines CRM-Systems.",
+        domain_knowledge="Das Unternehmen ist im B2B-Bereich tätig.",
+        language="de"
+    )
+    response = asyncio.run(async_get_categories_chain(request))
+    assert isinstance(response.categories, list)
+


### PR DESCRIPTION
## Summary
- support async invocation via `invoke_async`
- expose async wrappers for each chain
- add async tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684432e119b4832da5f27b35f2067fc1