### PR TITLE
Add presentation workflow using LangGraph

### DIFF
--- a/docs/design/prepare_presentation_output.md
+++ b/docs/design/prepare_presentation_output.md
@@ -1,0 +1,44 @@
+# Prepare Presentation Output
+
+The `prepare_presentation_output` workflow orchestrates existing chains with
+[LangGraph](https://github.com/langchain-ai/langgraph) to create a structured
+summary for slides or workshops.
+
+## Usage
+
+```python
+from riskgpt.workflows import prepare_presentation_output
+from riskgpt.models.schemas import PresentationRequest
+
+req = PresentationRequest(
+    project_id="p42",
+    project_description="Introduce a new CRM system",
+    audience="executive",
+    focus_areas=["Technical"],
+)
+result = prepare_presentation_output(req)
+print(result.executive_summary)
+```
+
+## Workflow
+
+```mermaid
+flowchart TD
+    A[Identify Risks] --> B[Assess Risks]
+    B -->|executive| E[Correlation Tags]
+    B -->|workshop| C[Identify Drivers]
+    C --> D[Mitigations]
+    C --> E
+    D --> E
+    E --> F[Summary]
+```
+
+## Example Output
+
+```
+Executive summary: <text>
+Main risks: ["Data loss", "Downtime"]
+Quantitative summary: Data loss: P=0.1, I=10000
+...
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ RiskGPT is a Python package for analyzing project-related risks and opportunitie
 - [Get Monitoring](get_monitoring.md) – derive indicators for ongoing monitoring
 - [Get Opportunities](get_opportunities.md) – detect positive developments
 - [Communicate Risks](communicate_risks.md) – create stakeholder summaries
+- [Prepare Presentation Output](design/prepare_presentation_output.md) – combine chains for slides
 
 ## Logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pydantic-settings = "^2.9.1"
 langchain-community = "^0.3.24"
 notebook = "^7.4.3"
 langchain-core = "^0.3.64"
+langgraph = "^0.0.32"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -244,3 +244,28 @@ class CorrelationTagResponse(BaseModel):
     tags: List[str]
     rationale: Optional[str] = None
     response_info: Optional[ResponseInfo] = None
+
+
+class PresentationRequest(BaseModel):
+    """Input model for presentation-oriented summaries."""
+
+    project_id: str
+    project_description: str
+    audience: str
+    focus_areas: Optional[List[str]] = None
+    language: Optional[str] = "en"
+
+
+class PresentationResponse(BaseModel):
+    """Structured output for presentation-ready summaries."""
+
+    executive_summary: str
+    main_risks: List[str]
+    quantitative_summary: Optional[str] = None
+    key_drivers: Optional[List[str]] = None
+    correlation_tags: Optional[List[str]] = None
+    mitigations: Optional[List[str]] = None
+    open_questions: Optional[List[str]] = None
+    chart_placeholders: Optional[List[str]] = None
+    appendix: Optional[str] = None
+    response_info: Optional[ResponseInfo] = None

--- a/riskgpt/workflows/__init__.py
+++ b/riskgpt/workflows/__init__.py
@@ -1,0 +1,6 @@
+"""Workflow orchestrations using LangGraph."""
+
+from .prepare_presentation_output import prepare_presentation_output
+
+__all__ = ["prepare_presentation_output"]
+

--- a/riskgpt/workflows/prepare_presentation_output.py
+++ b/riskgpt/workflows/prepare_presentation_output.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from riskgpt.logger import logger
+from riskgpt.models.schemas import (
+    PresentationRequest,
+    PresentationResponse,
+    RiskRequest,
+    AssessmentRequest,
+    MitigationRequest,
+    DriverRequest,
+    CorrelationTagRequest,
+    CommunicationRequest,
+)
+from riskgpt.chains import (
+    get_risks_chain,
+    get_assessment_chain,
+    get_mitigations_chain,
+    get_drivers_chain,
+    get_correlation_tags_chain,
+    communicate_risks_chain,
+)
+
+try:
+    from langgraph.graph import END, StateGraph
+except Exception:  # pragma: no cover - optional dependency
+    END = None
+    StateGraph = None
+
+
+def _build_graph(request: PresentationRequest):
+    if StateGraph is None:
+        raise ImportError("langgraph is required for this workflow")
+
+    graph = StateGraph(Dict[str, Any])
+
+    def identify_risks(state: Dict[str, Any]) -> Dict[str, Any]:
+        category = (request.focus_areas or ["General"])[0]
+        logger.info("Identify risks for category '%s'", category)
+        res = get_risks_chain(
+            RiskRequest(
+                project_id=request.project_id,
+                project_description=request.project_description,
+                category=category,
+                language=request.language,
+            )
+        )
+        state["risks"] = res.risks
+        return state
+
+    def assess_risks(state: Dict[str, Any]) -> Dict[str, Any]:
+        assessments = []
+        for risk in state.get("risks", []):
+            logger.info("Assess risk '%s'", risk.title)
+            assessments.append(
+                get_assessment_chain(
+                    AssessmentRequest(
+                        project_id=request.project_id,
+                        risk_description=risk.description,
+                        language=request.language,
+                    )
+                )
+            )
+        state["assessments"] = assessments
+        return state
+
+    def drivers(state: Dict[str, Any]) -> Dict[str, Any]:
+        driver_lists: List[List[str]] = []
+        for risk in state.get("risks", []):
+            logger.info("Get drivers for '%s'", risk.title)
+            res = get_drivers_chain(
+                DriverRequest(
+                    project_id=request.project_id,
+                    risk_description=risk.description,
+                    language=request.language,
+                )
+            )
+            driver_lists.append(res.drivers)
+        state["drivers"] = driver_lists
+        return state
+
+    def mitigations(state: Dict[str, Any]) -> Dict[str, Any]:
+        mitigation_lists: List[List[str]] = []
+        for risk, drv in zip(state.get("risks", []), state.get("drivers", [])):
+            logger.info("Get mitigations for '%s'", risk.title)
+            res = get_mitigations_chain(
+                MitigationRequest(
+                    project_id=request.project_id,
+                    risk_description=risk.description,
+                    drivers=drv,
+                    language=request.language,
+                )
+            )
+            mitigation_lists.append(res.mitigations)
+        state["mitigations"] = mitigation_lists
+        return state
+
+    def correlation(state: Dict[str, Any]) -> Dict[str, Any]:
+        titles = [r.title for r in state.get("risks", [])]
+        known = [d for lst in state.get("drivers", []) for d in lst]
+        logger.info("Define correlation tags")
+        res = get_correlation_tags_chain(
+            CorrelationTagRequest(
+                project_description=request.project_description,
+                risk_titles=titles,
+                known_drivers=known or None,
+                language=request.language,
+            )
+        )
+        state["correlation_tags"] = res.tags
+        return state
+
+    def summary(state: Dict[str, Any]) -> Dict[str, Any]:
+        lines = []
+        for risk, assess in zip(state.get("risks", []), state.get("assessments", [])):
+            line = f"{risk.title}: P={assess.probability or 'n/a'}, I={assess.impact or 'n/a'}"
+            lines.append(line)
+        text = "\n".join(lines)
+        com = communicate_risks_chain(
+            CommunicationRequest(
+                project_id=request.project_id,
+                summary=text,
+                language=request.language,
+            )
+        )
+        resp = PresentationResponse(
+            executive_summary=com.executive_summary,
+            main_risks=[r.title for r in state.get("risks", [])],
+            quantitative_summary=text,
+            key_drivers=[d for lst in state.get("drivers", []) for d in lst] or None,
+            correlation_tags=state.get("correlation_tags"),
+            mitigations=[m for lst in state.get("mitigations", []) for m in lst] or None,
+            open_questions=[],
+            chart_placeholders=["risk_overview_chart"],
+            appendix=com.technical_annex,
+        )
+        state["response"] = resp
+        return state
+
+    graph.add_node("identify_risks", identify_risks)
+    graph.add_node("assess_risks", assess_risks)
+    graph.add_node("drivers", drivers)
+    graph.add_node("mitigations", mitigations)
+    graph.add_node("correlation", correlation)
+    graph.add_node("summary", summary)
+
+    graph.set_entry_point("identify_risks")
+    graph.add_edge("identify_risks", "assess_risks")
+
+    if request.audience == "executive":
+        graph.add_edge("assess_risks", "correlation")
+    else:
+        graph.add_edge("assess_risks", "drivers")
+        if request.audience == "workshop":
+            graph.add_edge("drivers", "mitigations")
+            graph.add_edge("mitigations", "correlation")
+        else:
+            graph.add_edge("drivers", "correlation")
+
+    graph.add_edge("correlation", "summary")
+    graph.add_edge("summary", END)
+
+    return graph.compile()
+
+
+def prepare_presentation_output(request: PresentationRequest) -> PresentationResponse:
+    """Run the presentation workflow and return a structured response."""
+
+    app = _build_graph(request)
+    result = app.invoke({})
+    return result["response"]
+

--- a/tests/test_prepare_presentation_output.py
+++ b/tests/test_prepare_presentation_output.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytest.importorskip("langgraph")
+
+from riskgpt.workflows import prepare_presentation_output
+from riskgpt.models.schemas import PresentationRequest
+
+
+def test_prepare_presentation_executive():
+    request = PresentationRequest(
+        project_id="p1",
+        project_description="CRM rollout",
+        audience="executive",
+        focus_areas=["Technical"],
+        language="en",
+    )
+    resp = prepare_presentation_output(request)
+    assert resp.executive_summary
+    assert isinstance(resp.main_risks, list)
+
+
+def test_prepare_presentation_workshop():
+    request = PresentationRequest(
+        project_id="p2",
+        project_description="ERP migration",
+        audience="workshop",
+        focus_areas=["Technical"],
+        language="en",
+    )
+    resp = prepare_presentation_output(request)
+    assert resp.mitigations is not None
+


### PR DESCRIPTION
## Summary
- orchestrate chains with LangGraph in `prepare_presentation_output`
- add `PresentationRequest` and `PresentationResponse` models
- document the workflow and link from index
- include example and mermaid diagram in design docs
- extend project dependencies and add tests for the new workflow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684452d3fddc832d802f5ea56adb3fd3