### PR TITLE
Fix playground notebook and add metachain example

### DIFF
--- a/notebooks/playground.ipynb
+++ b/notebooks/playground.ipynb
@@ -528,7 +528,6 @@
     "\n",
     "communication_response = communicate_risks_chain(communication_request)\n",
     "print(communication_response.model_dump_json(indent=2))\n"
-
    ]
   },
   {
@@ -552,26 +551,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from riskgpt.chains import get_correlation_tags_chain\n",
-    "from riskgpt.models.schemas import CorrelationTagRequest\n",
-    "\n",
-    "tag_request = CorrelationTagRequest(\n",
-    "    project_description=\"CRM rollout\",\n",
-    "    risk_titles=[r.title for r in risk_response.risks],\n",
-    "    known_drivers=driver_response.drivers,\n",
-    "    domain_knowledge=\"The company operates in the B2B market.\",\n",
-    "    language=\"en\"\n",
-    ")\n",
-    "\n",
-    "tag_response = get_correlation_tags_chain(tag_request)\n",
-    "print(tag_response.model_dump_json(indent=2))\n"
-   ]
-=======
-   ],
-   "id": "1c86b8deede5e434",
+   "execution_count": 9,
    "outputs": [
     {
      "name": "stdout",
@@ -589,8 +569,43 @@
      ]
     }
    ],
-   "execution_count": 9
-
+   "source": [
+    "from riskgpt.chains import get_correlation_tags_chain\n",
+    "from riskgpt.models.schemas import CorrelationTagRequest\n",
+    "\n",
+    "tag_request = CorrelationTagRequest(\n",
+    "    project_description=\"CRM rollout\",\n",
+    "    risk_titles=[r.title for r in risk_response.risks],\n",
+    "    known_drivers=driver_response.drivers,\n",
+    "    domain_knowledge=\"The company operates in the B2B market.\",\n",
+    "    language=\"en\"\n",
+    ")\n",
+    "\n",
+    "tag_response = get_correlation_tags_chain(tag_request)\n",
+    "print(tag_response.model_dump_json(indent=2))\n"
+   ],
+   "id": "1c86b8deede5e434"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from riskgpt.workflows import prepare_presentation_output\n",
+    "from riskgpt.models.schemas import PresentationRequest\n",
+    "\n",
+    "presentation_request = PresentationRequest(\n",
+    "    project_id=\"demo\",\n",
+    "    project_description=\"Introduce a new CRM system\",\n",
+    "    audience=\"executive\",\n",
+    "    focus_areas=[\"Technical\"],\n",
+    "    language=\"en\"\n",
+    ")\n",
+    "\n",
+    "presentation_response = prepare_presentation_output(presentation_request)\n",
+    "print(presentation_response.model_dump_json(indent=2))\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- fix JSON error in `playground.ipynb`
- add example cell showing `prepare_presentation_output` metachain

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_68445a1e679c832d862e169deea9a2e7