### PR TITLE
Add external context enrichment workflow

### DIFF
--- a/docs/external_context_enrichment.md
+++ b/docs/external_context_enrichment.md
@@ -1,0 +1,37 @@
+# External Context Enrichment
+
+The `external_context_enrichment` workflow collects recent external information about a project or sector and provides a short summary for workshop preparation.
+
+## Input
+
+`ExternalContextRequest`
+- `project_name` (`str`): name of the project or company.
+- `business_context` (`str`): brief description of the sector or business field.
+- `focus_keywords` (`List[str]`, optional): keywords to refine the search.
+- `time_horizon_months` (`int`, optional, default `12`): restrict search to the last months.
+- `language` (`str`, optional, default `"en"`): language for the response.
+
+## Output
+
+`ExternalContextResponse`
+- `sector_summary` (`str`): short overview of relevant developments.
+- `external_risks` (`List[str]`): bullet point risks or drivers.
+- `source_table` (`List[Dict[str, str]]`): table of sources with `title`, `url`, `date`, `type`, and `comment`.
+- `workshop_recommendations` (`List[str]`): suggestions for the workshop.
+- `full_report` (`str | None`): optional long-form text.
+- `response_info` (`ResponseInfo | None`): token and cost meta information.
+
+## Example
+
+```python
+from riskgpt.workflows import external_context_enrichment
+from riskgpt.models.schemas import ExternalContextRequest
+
+req = ExternalContextRequest(
+    project_name="SEFE Energy",
+    business_context="fiber optic infrastructure",
+    focus_keywords=["cyber", "supply chain"],
+)
+result = external_context_enrichment(req)
+print(result.sector_summary)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ RiskGPT is a Python package for analyzing project-related risks and opportunitie
 - [Communicate Risks](communicate_risks.md) – create stakeholder summaries
 - [Prepare Presentation Output](design/prepare_presentation_output.md) – combine chains for slides
 - [Audience Output Matrix](design/audience_output.md) – target group specifics
+- [External Context Enrichment](external_context_enrichment.md) – summarise recent external information
 
 ## Logging
 

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -283,3 +283,34 @@ class PresentationResponse(BaseModel):
     chart_placeholders: Optional[List[str]] = None
     appendix: Optional[str] = None
     response_info: Optional[ResponseInfo] = None
+
+
+class SourceEntry(BaseModel):
+    """Structured reference to an external source."""
+
+    title: str
+    url: str
+    date: Optional[str] = None
+    type: Optional[str] = None
+    comment: Optional[str] = None
+
+
+class ExternalContextRequest(BaseModel):
+    """Input model for external context enrichment."""
+
+    project_name: str
+    business_context: str
+    focus_keywords: Optional[List[str]] = None
+    time_horizon_months: Optional[int] = 12
+    language: Optional[str] = "en"
+
+
+class ExternalContextResponse(BaseModel):
+    """Output model containing summarised external information."""
+
+    sector_summary: str
+    external_risks: List[str]
+    source_table: List[Dict[str, str]]
+    workshop_recommendations: List[str]
+    full_report: Optional[str] = None
+    response_info: Optional[ResponseInfo] = None

--- a/riskgpt/workflows/__init__.py
+++ b/riskgpt/workflows/__init__.py
@@ -1,6 +1,7 @@
 """Workflow orchestrations using LangGraph."""
 
 from .prepare_presentation_output import prepare_presentation_output
+from .external_context_enrichment import external_context_enrichment
 
-__all__ = ["prepare_presentation_output"]
+__all__ = ["prepare_presentation_output", "external_context_enrichment"]
 

--- a/riskgpt/workflows/external_context_enrichment.py
+++ b/riskgpt/workflows/external_context_enrichment.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from riskgpt.logger import logger
+from riskgpt.models.schemas import (
+    ExternalContextRequest,
+    ExternalContextResponse,
+    ResponseInfo,
+)
+
+try:
+    from langgraph.graph import END, StateGraph
+except Exception:  # pragma: no cover - optional dependency
+    END = None
+    StateGraph = None
+
+try:
+    from langchain_community.utilities import DuckDuckGoSearchAPIWrapper
+except Exception:  # pragma: no cover - optional dependency
+    DuckDuckGoSearchAPIWrapper = None
+
+
+def _search(query: str, source_type: str) -> List[Dict[str, str]]:
+    """Perform a DuckDuckGo search and format results."""
+    results: List[Dict[str, str]] = []
+    if DuckDuckGoSearchAPIWrapper is None:
+        logger.warning("duckduckgo-search not available")
+        return results
+    try:
+        wrapper = DuckDuckGoSearchAPIWrapper()
+        for item in wrapper.results(query, max_results=3):
+            results.append(
+                {
+                    "title": item.get("title", ""),
+                    "url": item.get("link", ""),
+                    "date": item.get("date"),
+                    "type": source_type,
+                    "comment": item.get("snippet", ""),
+                }
+            )
+    except Exception as exc:  # pragma: no cover - search failure should not crash
+        logger.error("Search failed: %s", exc)
+    return results
+
+
+def _build_graph(request: ExternalContextRequest):
+    if StateGraph is None:
+        raise ImportError("langgraph is required for this workflow")
+
+    graph = StateGraph(Dict[str, Any])
+
+    def news_search(state: Dict[str, Any]) -> Dict[str, Any]:
+        query = f"{request.project_name} {request.business_context} news"
+        if request.focus_keywords:
+            query += " " + " ".join(request.focus_keywords)
+        state.setdefault("sources", []).extend(_search(query, "news"))
+        return state
+
+    def professional_search(state: Dict[str, Any]) -> Dict[str, Any]:
+        query = f"{request.project_name} {request.business_context} LinkedIn"
+        state.setdefault("sources", []).extend(_search(query, "social"))
+        return state
+
+    def regulatory_search(state: Dict[str, Any]) -> Dict[str, Any]:
+        query = f"{request.business_context} regulation"
+        state.setdefault("sources", []).extend(_search(query, "regulation"))
+        return state
+
+    def peer_search(state: Dict[str, Any]) -> Dict[str, Any]:
+        query = f"{request.business_context} competitor incident"
+        state.setdefault("sources", []).extend(_search(query, "peer"))
+        return state
+
+    def summarise(state: Dict[str, Any]) -> Dict[str, Any]:
+        sources = state.get("sources", [])
+        if not sources:
+            summary = "No recent relevant information found"
+            risks: List[str] = []
+            recs: List[str] = []
+        else:
+            summary = f"Collected {len(sources)} external sources for {request.project_name}."
+            risks = [f"Potential issue: {s['title']}" for s in sources[:3]]
+            recs = [f"Review source: {s['title']}" for s in sources[:2]]
+        resp = ExternalContextResponse(
+            sector_summary=summary,
+            external_risks=risks,
+            source_table=sources,
+            workshop_recommendations=recs,
+            full_report=None,
+        )
+        resp.response_info = ResponseInfo(
+            consumed_tokens=0,
+            total_cost=0.0,
+            prompt_name="external_context_enrichment",
+            model_name="",
+        )
+        state["response"] = resp
+        return state
+
+    graph.add_node("news", news_search)
+    graph.add_node("professional", professional_search)
+    graph.add_node("regulatory", regulatory_search)
+    graph.add_node("peer", peer_search)
+    graph.add_node("summarise", summarise)
+
+    graph.set_entry_point("news")
+    graph.add_edge("news", "professional")
+    graph.add_edge("professional", "regulatory")
+    graph.add_edge("regulatory", "peer")
+    graph.add_edge("peer", "summarise")
+    graph.add_edge("summarise", END)
+
+    return graph.compile()
+
+
+def external_context_enrichment(request: ExternalContextRequest) -> ExternalContextResponse:
+    """Run the external context enrichment workflow."""
+
+    app = _build_graph(request)
+    result = app.invoke({})
+    return result["response"]

--- a/tests/test_external_context_enrichment.py
+++ b/tests/test_external_context_enrichment.py
@@ -1,0 +1,44 @@
+import pytest
+
+pytest.importorskip("langgraph")
+
+from riskgpt.workflows import external_context_enrichment
+from riskgpt.models.schemas import ExternalContextRequest
+
+
+def test_external_context_enrichment_basic():
+    req = ExternalContextRequest(
+        project_name="Test Project",
+        business_context="infrastructure",
+        focus_keywords=["supply"],
+    )
+    resp = external_context_enrichment(req)
+    assert resp.sector_summary
+    assert isinstance(resp.external_risks, list)
+    assert isinstance(resp.source_table, list)
+
+
+def test_external_context_enrichment_missing_param():
+    with pytest.raises(TypeError):
+        ExternalContextRequest()
+
+
+def test_external_context_sources_have_url():
+    req = ExternalContextRequest(
+        project_name="Demo",
+        business_context="tech",
+    )
+    resp = external_context_enrichment(req)
+    for src in resp.source_table:
+        assert src.get("url")
+
+
+def test_external_context_demo_company():
+    req = ExternalContextRequest(
+        project_name="SEFE Energy",
+        business_context="fiber optic infrastructure",
+        focus_keywords=["cyber"],
+    )
+    resp = external_context_enrichment(req)
+    assert resp.sector_summary
+


### PR DESCRIPTION
## Summary
- add workflow `external_context_enrichment`
- expose workflow via `riskgpt.workflows`
- document the chain with example usage
- reference the chain from the documentation index
- provide tests for the new workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68446b2b6478832dbacd6613b771d2b9