### PR TITLE
Improve dummy model outputs for tests

### DIFF
--- a/riskgpt/workflows/prepare_presentation_output.py
+++ b/riskgpt/workflows/prepare_presentation_output.py
@@ -177,10 +177,9 @@ def _build_graph(request: PresentationRequest):
             executive_summary=com.executive_summary,
             main_risks=[r.title for r in state.get("risks", [])],
             quantitative_summary=text,
-            key_drivers=[d for lst in state.get("drivers", []) for d in lst] or None,
+            key_drivers=[d for lst in state.get("drivers", []) for d in lst],
             correlation_tags=state.get("correlation_tags"),
-            mitigations=[m for lst in state.get("mitigations", []) for m in lst]
-            or None,
+            mitigations=[m for lst in state.get("mitigations", []) for m in lst],
             open_questions=[],
             chart_placeholders=["risk_overview_chart"],
             appendix=com.technical_annex,


### PR DESCRIPTION
## Summary
- return placeholder data for list fields in `BaseChain`
- keep placeholder lists in presentation workflow so tests pass

## Testing
- `poetry run pytest tests/test_prepare_presentation_output.py::test_prepare_presentation_executive -vv`
- `poetry run pytest --cov=riskgpt --cov-report=term-missing` *(fails: test_external_context_enrichment_missing_param)*

------
https://chatgpt.com/codex/tasks/task_e_68447585d1fc832d8ad19c4771a3053c