### PR TITLE
Add optional LangServe playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ configure_logging()
 
 See the `docs/` directory for detailed documentation. An example Jupyter notebook is available in `notebooks/playground.ipynb` for an interactive playground.
 
+If you prefer a web interface to explore the chains, RiskGPT also provides an
+optional [LangServe](https://github.com/langchain-ai/langserve) playground.
+Install with the `serve` extra and run:
+
+```bash
+python -m riskgpt.playground.langserve_app
+```
+
 Validation helpers such as `validate_risk_request()` are available in `riskgpt.processors.input_validator` to convert dictionaries into request objects.
 
 ## Installation
@@ -27,6 +35,12 @@ Install the latest release from PyPI:
 
 ```bash
 pip install riskgpt
+```
+
+To enable the optional LangServe playground install with the `serve` extra:
+
+```bash
+pip install riskgpt[serve]
 ```
 
 For development this project uses [Poetry](https://python-poetry.org/) for dependency management. Install all dependencies including the development tools with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,13 @@ Install the latest release from [PyPI](https://pypi.org/project/riskgpt/):
 pip install riskgpt
 ```
 
+To try the LangServe playground:
+
+```bash
+pip install riskgpt[serve]
+python -m riskgpt.playground.langserve_app
+```
+
 ## Features
 
 - Extract risk categories from project descriptions

--- a/docs/langserve.md
+++ b/docs/langserve.md
@@ -1,0 +1,12 @@
+# LangServe Playground
+
+LangServe provides a simple web UI to experiment with RiskGPT chains and workflows.
+After installing with `pip install riskgpt[serve]` you can start the playground with:
+
+```bash
+python -m riskgpt.playground.langserve_app
+```
+
+The browser interface lists available chains on the left. Selecting one shows the
+input fields and allows you to run the chain interactively. Results appear on the
+right side of the page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ theme:
   name: material
 nav:
   - Home: index.md
+  - LangServe Playground: langserve.md
   - Chains:
       - Get Categories: get_categories.md
       - Check Definition: check_definition.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ notebook = "^7.4.3"
 langchain-core = "^0.3.64"
 langgraph = "^0.4.8"
 duckduckgo-search = "^8.0.2"
+langserve = {version = "^0.3.1", extras = ["server"], optional = true}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"
@@ -42,6 +43,9 @@ pre-commit = "^3.7.1"
 
 [tool.pytest.ini_options]
 pythonpath = ["riskgpt"]
+
+[tool.poetry.extras]
+serve = ["langserve"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/riskgpt/config/memory.py
+++ b/riskgpt/config/memory.py
@@ -2,7 +2,7 @@
 
 from typing import Literal, Optional
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 from riskgpt.config.settings import RiskGPTSettings
 from riskgpt.utils.memory_factory import (

--- a/riskgpt/playground/langserve_app.py
+++ b/riskgpt/playground/langserve_app.py
@@ -1,0 +1,60 @@
+"""LangServe playground for RiskGPT.
+
+Run ``python -m riskgpt.playground.langserve_app`` after installing
+``riskgpt[serve]`` to launch a local web UI exposing several chains.
+"""
+
+from __future__ import annotations
+
+try:
+    from fastapi import FastAPI
+    from langchain_core.runnables import RunnableLambda
+    from langserve import add_routes
+except Exception as exc:  # pragma: no cover - optional dependency
+    raise SystemExit("LangServe and FastAPI are required for the playground.") from exc
+
+from riskgpt.chains import get_categories_chain, get_risks_chain
+from riskgpt.models.schemas import (
+    CategoryRequest,
+    ContextQualityRequest,
+    PresentationRequest,
+    RiskRequest,
+)
+from riskgpt.workflows import check_context_quality, prepare_presentation_output
+
+app = FastAPI(title="RiskGPT Playground")
+
+add_routes(
+    app,
+    RunnableLambda(lambda data: get_categories_chain(CategoryRequest(**data))),
+    path="/get_categories",
+    input_type=CategoryRequest,
+)
+
+add_routes(
+    app,
+    RunnableLambda(lambda data: get_risks_chain(RiskRequest(**data))),
+    path="/get_risks",
+    input_type=RiskRequest,
+)
+
+add_routes(
+    app,
+    RunnableLambda(lambda data: check_context_quality(ContextQualityRequest(**data))),
+    path="/check_context_quality",
+    input_type=ContextQualityRequest,
+)
+
+add_routes(
+    app,
+    RunnableLambda(
+        lambda data: prepare_presentation_output(PresentationRequest(**data))
+    ),
+    path="/prepare_presentation_output",
+    input_type=PresentationRequest,
+)
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/riskgpt/utils/memory_factory.py
+++ b/riskgpt/utils/memory_factory.py
@@ -38,7 +38,7 @@ def _redis_memory(settings: RiskGPTSettings) -> ConversationBufferMemory:
 
     if not settings.REDIS_URL:
         raise ValueError("REDIS_URL must be set for redis memory backend")
-    history = RedisChatMessageHistory(url=settings.REDIS_URL)
+    history = RedisChatMessageHistory(url=settings.REDIS_URL, session_id="default")
     return ConversationBufferMemory(chat_memory=history, return_messages=True)
 
 

--- a/riskgpt/workflows/external_context_enrichment.py
+++ b/riskgpt/workflows/external_context_enrichment.py
@@ -9,14 +9,23 @@ from riskgpt.models.schemas import (
     ResponseInfo,
 )
 
+END: Any
+StateGraph: Any
 try:
-    from langgraph.graph import END, StateGraph
+    from langgraph.graph import END as _END
+    from langgraph.graph import StateGraph as _StateGraph
+
+    END = _END
+    StateGraph = _StateGraph
 except Exception:  # pragma: no cover - optional dependency
     END = None
     StateGraph = None
 
+DuckDuckGoSearchAPIWrapper: Any
 try:
-    from langchain_community.utilities import DuckDuckGoSearchAPIWrapper
+    from langchain_community.utilities import DuckDuckGoSearchAPIWrapper as _Wrapper
+
+    DuckDuckGoSearchAPIWrapper = _Wrapper
 except Exception:  # pragma: no cover - optional dependency
     DuckDuckGoSearchAPIWrapper = None
 

--- a/riskgpt/workflows/prepare_presentation_output.py
+++ b/riskgpt/workflows/prepare_presentation_output.py
@@ -51,8 +51,14 @@ def apply_audience_formatting(
     return resp
 
 
+END: Any
+StateGraph: Any
 try:
-    from langgraph.graph import END, StateGraph
+    from langgraph.graph import END as _END
+    from langgraph.graph import StateGraph as _StateGraph
+
+    END = _END
+    StateGraph = _StateGraph
 except Exception:  # pragma: no cover - optional dependency
     END = None
     StateGraph = None
@@ -65,7 +71,7 @@ def _build_graph(request: PresentationRequest):
     graph = StateGraph(Dict[str, Any])
 
     settings = RiskGPTSettings()
-    totals = {"tokens": 0, "cost": 0.0}
+    totals: Dict[str, float | int] = {"tokens": 0, "cost": 0.0}
 
     def identify_risks(state: Dict[str, Any]) -> Dict[str, Any]:
         category = (request.focus_areas or ["General"])[0]
@@ -185,8 +191,8 @@ def _build_graph(request: PresentationRequest):
             appendix=com.technical_annex,
         )
         resp.response_info = ResponseInfo(
-            consumed_tokens=totals["tokens"],
-            total_cost=totals["cost"],
+            consumed_tokens=int(totals["tokens"]),
+            total_cost=float(totals["cost"]),
             prompt_name="prepare_presentation_output",
             model_name=settings.OPENAI_MODEL_NAME,
         )

--- a/tests/test_langserve_app.py
+++ b/tests/test_langserve_app.py
@@ -1,0 +1,26 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")  # noqa: E402
+langserve = pytest.importorskip("langserve")  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from riskgpt.playground.langserve_app import app  # noqa: E402
+
+
+def test_langserve_app_invocation():
+    client = TestClient(app)
+    resp = client.post(
+        "/get_categories/invoke",
+        json={
+            "input": {
+                "project_id": "1",
+                "project_description": "Test project",
+                "domain_knowledge": None,
+                "language": "en",
+            }
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "output" in data and "categories" in data["output"]


### PR DESCRIPTION
## Summary
- include optional dependency `langserve` and add `[serve]` extra
- expose chains in new `riskgpt.playground.langserve_app`
- document usage in README and docs
- add MkDocs page for LangServe
- provide basic test for LangServe app

## Testing
- `ruff check riskgpt/workflows/prepare_presentation_output.py riskgpt/workflows/external_context_enrichment.py riskgpt/utils/memory_factory.py --fix`
- `black riskgpt/workflows/prepare_presentation_output.py riskgpt/workflows/external_context_enrichment.py riskgpt/utils/memory_factory.py`
- `mypy . | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684570930264832d9efe154bf9f3f643