### PR TITLE
Fix LangServe openapi generation

### DIFF
--- a/riskgpt/playground/langserve_app.py
+++ b/riskgpt/playground/langserve_app.py
@@ -24,11 +24,23 @@ from riskgpt.workflows import check_context_quality, prepare_presentation_output
 
 app = FastAPI(title="RiskGPT Playground")
 
+
+def custom_openapi() -> dict:
+    """Generate OpenAPI schema without batch endpoints."""
+    from fastapi.openapi.utils import get_openapi
+
+    filtered_routes = [r for r in app.router.routes if "/batch" not in r.path]
+    return get_openapi(title=app.title, version="1.0.0", routes=filtered_routes)
+
+
+app.openapi = custom_openapi
+
 add_routes(
     app,
     RunnableLambda(lambda data: get_categories_chain(CategoryRequest(**data))),
     path="/get_categories",
     input_type=CategoryRequest,
+    disabled_endpoints=["batch"],
 )
 
 add_routes(
@@ -36,6 +48,7 @@ add_routes(
     RunnableLambda(lambda data: get_risks_chain(RiskRequest(**data))),
     path="/get_risks",
     input_type=RiskRequest,
+    disabled_endpoints=["batch"],
 )
 
 add_routes(
@@ -43,6 +56,7 @@ add_routes(
     RunnableLambda(lambda data: check_context_quality(ContextQualityRequest(**data))),
     path="/check_context_quality",
     input_type=ContextQualityRequest,
+    disabled_endpoints=["batch"],
 )
 
 add_routes(
@@ -52,6 +66,7 @@ add_routes(
     ),
     path="/prepare_presentation_output",
     input_type=PresentationRequest,
+    disabled_endpoints=["batch"],
 )
 
 if __name__ == "__main__":  # pragma: no cover - manual start


### PR DESCRIPTION
## Summary
- patch langserve playground to filter batch routes and avoid Pydantic errors
- disable batch endpoints for all chains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457f0d8618832db04a51a6c436a1b9