### PR TITLE
Extend categories and risks features

### DIFF
--- a/docs/get_categories.md
+++ b/docs/get_categories.md
@@ -8,6 +8,7 @@ The `get_categories` chain identifies relevant risk categories for a project des
 - `project_id` (`str`): unique identifier of the project.
 - `project_description` (`str`): description of the project.
 - `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `existing_categories` (`List[str]`, optional): predefined categories to extend.
 - `language` (`str`, optional, default `"en"`): language for the response.
 
 ## Output
@@ -27,6 +28,7 @@ request = CategoryRequest(
     project_id="123",
     project_description="An IT project to introduce a new CRM system.",
     domain_knowledge="The company operates in the B2B market.",
+    existing_categories=["technical", "strategic"],
     language="de"
 )
 

--- a/docs/get_risks.md
+++ b/docs/get_risks.md
@@ -10,6 +10,7 @@ The `get_risks` chain identifies specific risks for a given risk category.
 - `category` (`str`): the risk category to analyse.
 - `max_risks` (`int`, optional, default `5`): maximum number of risks to return.
 - `domain_knowledge` (`str`, optional): additional domain-specific context.
+- `existing_risks` (`List[str]`, optional): already identified risks to exclude.
 - `language` (`str`, optional, default `"en"`): language for the response.
 
 ## Output
@@ -31,6 +32,7 @@ request = RiskRequest(
     category="Technical",
     max_risks=5,
     domain_knowledge="The company operates in the B2B market.",
+    existing_risks=["Data loss"],
     language="de"
 )
 

--- a/riskgpt/chains/get_categories.py
+++ b/riskgpt/chains/get_categories.py
@@ -27,6 +27,11 @@ def get_categories_chain(request: CategoryRequest) -> CategoryResponse:
         if request.domain_knowledge
         else ""
     )
+    inputs["existing_categories_section"] = (
+        f"Existing categories: {', '.join(request.existing_categories)}"
+        if request.existing_categories
+        else ""
+    )
 
     return chain.invoke(inputs)
 
@@ -48,6 +53,11 @@ async def async_get_categories_chain(request: CategoryRequest) -> CategoryRespon
     inputs["domain_section"] = (
         f"Domain knowledge: {request.domain_knowledge}"
         if request.domain_knowledge
+        else ""
+    )
+    inputs["existing_categories_section"] = (
+        f"Existing categories: {', '.join(request.existing_categories)}"
+        if request.existing_categories
         else ""
     )
 

--- a/riskgpt/chains/get_risks.py
+++ b/riskgpt/chains/get_risks.py
@@ -28,6 +28,11 @@ def get_risks_chain(request: RiskRequest) -> RiskResponse:
         if request.domain_knowledge
         else ""
     )
+    inputs["existing_risks_section"] = (
+        f"Existing risks: {', '.join(request.existing_risks)}"
+        if request.existing_risks
+        else ""
+    )
     inputs["system_prompt"] = system_prompt
 
     return chain.invoke(inputs)
@@ -51,6 +56,11 @@ async def async_get_risks_chain(request: RiskRequest) -> RiskResponse:
     inputs["domain_section"] = (
         f"Domain knowledge: {request.domain_knowledge}"
         if request.domain_knowledge
+        else ""
+    )
+    inputs["existing_risks_section"] = (
+        f"Existing risks: {', '.join(request.existing_risks)}"
+        if request.existing_risks
         else ""
     )
     inputs["system_prompt"] = system_prompt

--- a/riskgpt/models/schemas.py
+++ b/riskgpt/models/schemas.py
@@ -30,6 +30,7 @@ class CategoryRequest(BaseModel):
     project_id: str
     project_description: str
     domain_knowledge: Optional[str] = None
+    existing_categories: Optional[List[str]] = None
     language: Optional[str] = "en"
 
 
@@ -47,6 +48,7 @@ class RiskRequest(BaseModel):
     category: str
     max_risks: Optional[int] = 5
     domain_knowledge: Optional[str] = None
+    existing_risks: Optional[List[str]] = None
     language: Optional[str] = "en"
 
 

--- a/riskgpt/prompts/get_categories/v1.yaml
+++ b/riskgpt/prompts/get_categories/v1.yaml
@@ -4,8 +4,10 @@ template: |
   You are a risk analyst.
   Project description: {project_description}
   {domain_section}
+  {existing_categories_section}
 
   Please identify the relevant risk categories for this project.
+  If existing categories are provided, extend the list with any additional categories that make sense.
   Briefly explain each category.
   Respond in the following language: {language}
   

--- a/riskgpt/prompts/get_risks/v1.yaml
+++ b/riskgpt/prompts/get_risks/v1.yaml
@@ -4,8 +4,10 @@ template: |
   {system_prompt}
   Project description: {project_description}
   {domain_section}
+  {existing_risks_section}
 
   Identify the most important risks in the category: {category}.
+  If existing risks are provided, propose additional risks that are not on the list.
   List no more than {max_risks} risks.
   Each risk must have a short title and a description using the event, cause, consequence structure.
   Support the risks with references to studies or academic papers and list the references in Harvard style.

--- a/tests/test_get_categories.py
+++ b/tests/test_get_categories.py
@@ -1,6 +1,3 @@
-
-
-
 from riskgpt.chains.get_categories import get_categories_chain
 from riskgpt.models.schemas import CategoryRequest
 
@@ -10,6 +7,7 @@ def test_get_categories_chain():
         project_id="123",
         project_description="Ein neues IT-Projekt zur Einführung eines CRM-Systems.",
         domain_knowledge="Das Unternehmen ist im B2B-Bereich tätig.",
+        existing_categories=["Technisch"],
         language="de",
     )
     response = get_categories_chain(request)

--- a/tests/test_get_risks.py
+++ b/tests/test_get_risks.py
@@ -1,5 +1,3 @@
-
-
 from riskgpt.chains.get_risks import get_risks_chain
 from riskgpt.models.schemas import RiskRequest
 
@@ -10,6 +8,7 @@ def test_get_risks_chain():
         project_description="Ein neues IT-Projekt zur Einführung eines CRM-Systems.",
         category="Technisch",
         domain_knowledge="Das Unternehmen ist im B2B-Bereich tätig.",
+        existing_risks=["Datenverlust"],
         language="de",
     )
     response = get_risks_chain(request)


### PR DESCRIPTION
## Summary
- allow `CategoryRequest` to take optional existing categories
- handle optional existing risks in `RiskRequest`
- support the new options in `get_categories` and `get_risks` chains
- update prompts and docs
- adjust unit tests for new parameters

## Testing
- `pre-commit run --files docs/get_categories.md docs/get_risks.md riskgpt/chains/get_categories.py riskgpt/chains/get_risks.py riskgpt/models/schemas.py riskgpt/prompts/get_categories/v1.yaml riskgpt/prompts/get_risks/v1.yaml tests/test_get_categories.py tests/test_get_risks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bad485d0832dabcea67ee24df2bf