### PR TITLE
Remove simple mode from risk workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - Deprecate get_risks_chain and get_assessment_chain in favor of the new Risk Workflow
 - Mark legacy chains with deprecation warnings
+- Remove simple mode from the risk workflow and always run full workflow
 
 ### 📚 Documentation
 

--- a/docs/risk_workflow.md
+++ b/docs/risk_workflow.md
@@ -6,12 +6,12 @@ The Risk Workflow orchestrates the risk identification and assessment process, i
 
 The Risk Workflow combines multiple steps into a single workflow:
 
-1. Web search for relevant context (when using full workflow)
-2. Document retrieval from the document microservice (when using full workflow)
+1. Web search for relevant context
+2. Document retrieval from the document microservice
 3. Risk identification (using direct implementation to avoid circular dependency)
 4. Risk assessment (when using full workflow)
 
-This workflow is designed to replace the individual chains with a more integrated approach that can leverage web search results and document references. It also provides a simpler mode that skips the search, document integration, and assessment steps for faster processing.
+This workflow replaces the individual chains with a single graph that leverages web search results and document references for improved context.
 
 ## Usage
 
@@ -33,11 +33,8 @@ request = RiskRequest(
     existing_risks=["Data migration failure"],
 )
 
-# Run the workflow with full capabilities (default)
+# Run the workflow
 response = risk_workflow(request)
-
-# Or run in simple mode (faster, no search or assessment)
-simple_response = risk_workflow(request, use_full_workflow=False)
 
 # Access the results
 for risk in response.risks:
@@ -67,11 +64,8 @@ async def main():
     # Create a request (same as above)
     # ...
 
-    # Run the workflow asynchronously with full capabilities
+    # Run the workflow asynchronously
     response = await async_risk_workflow(request)
-
-    # Or run in simple mode (faster, no search or assessment)
-    simple_response = await async_risk_workflow(request, use_full_workflow=False)
 
     # Access the results (same as above)
     # ...
@@ -84,8 +78,8 @@ asyncio.run(main())
 The workflow includes integration with web search providers to find relevant context for risk identification. This uses the same search functionality as the external_context_enrichment workflow.
 
 ```python
-# The search is performed automatically when using the full workflow
-response = risk_workflow(request, use_full_workflow=True)
+# The search is performed automatically by the workflow
+response = risk_workflow(request)
 
 # Access search references in the response
 if response.references:

--- a/docs/schemas_assessment.md
+++ b/docs/schemas_assessment.md
@@ -186,7 +186,7 @@ if response.quantitative:
 
 ### Assessment in Risk Workflow
 
-The assessment models are also used in the risk workflow when `use_full_workflow=True`:
+The assessment models are also used in the risk workflow:
 
 ```python
 from riskgpt.models.schemas import BusinessContext, RiskRequest
@@ -204,7 +204,7 @@ request = RiskRequest(
 )
 
 # Run the workflow with full capabilities (includes assessment)
-response = risk_workflow(request, use_full_workflow=True)
+response = risk_workflow(request)
 
 # The assessments are performed internally in the workflow
 # but are not directly accessible in the response

--- a/riskgpt/workflows/risk_workflow.py
+++ b/riskgpt/workflows/risk_workflow.py
@@ -96,14 +96,12 @@ def _identify_risks_directly(request: RiskRequest) -> RiskResponse:
     return chain.invoke(inputs)
 
 
-def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = True):
+def _build_risk_workflow_graph(request: RiskRequest):
     """
     Build and compile the risk workflow graph.
 
     Args:
         request: The risk request containing business context and category
-        use_full_workflow: Whether to use the full workflow capabilities (search, document integration)
-                          or a simpler version similar to the legacy chains
     """
     if StateGraph is None:
         raise ImportError("langgraph is required for this workflow")
@@ -122,16 +120,10 @@ def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = T
             # Use the request passed to _build_graph
             state["request"] = request
 
-        # Store whether we're using the full workflow
-        state["use_full_workflow"] = use_full_workflow
         return state
 
     def search_for_context(state: Dict[str, Any]) -> Dict[str, Any]:
         """Search for relevant context using the search provider."""
-        if not state.get("use_full_workflow", True):
-            # Skip this step if not using full workflow
-            return state
-
         req = state["request"]
         logger.info("Searching for context related to '%s'", req.category)
 
@@ -156,10 +148,6 @@ def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = T
 
     def fetch_documents(state: Dict[str, Any]) -> Dict[str, Any]:
         """Fetch relevant documents for the business context."""
-        if not state.get("use_full_workflow", True):
-            # Skip this step if not using full workflow
-            return state
-
         req = state["request"]
         logger.info(
             "Fetching documents for project '%s'", req.business_context.project_id
@@ -214,11 +202,6 @@ def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = T
 
     def assess_risks(state: Dict[str, Any]) -> Dict[str, Any]:
         """Assess each identified risk using the get_assessment_chain."""
-        if not state.get("use_full_workflow", True):
-            # Skip risk assessment if not using full workflow
-            # Just return the state with the identified risks
-            return state
-
         req = state["request"]
         assessments = []
 
@@ -306,61 +289,49 @@ def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = T
     # Set the entry point
     graph.set_entry_point("initialize")
 
-    # Add edges to define the flow
-    if use_full_workflow:
-        # Full workflow with search and document integration
-        graph.add_edge("initialize", "search_for_context")
-        graph.add_edge("search_for_context", "fetch_documents")
-        graph.add_edge("fetch_documents", "identify_risks")
-        graph.add_edge("identify_risks", "assess_risks")
-        graph.add_edge("assess_risks", "prepare_response")
-    else:
-        # Simple workflow similar to legacy chains
-        graph.add_edge("initialize", "identify_risks")
-        graph.add_edge("identify_risks", "prepare_response")
+    # Add edges to define the flow (always full workflow)
+    graph.add_edge("initialize", "search_for_context")
+    graph.add_edge("search_for_context", "fetch_documents")
+    graph.add_edge("fetch_documents", "identify_risks")
+    graph.add_edge("identify_risks", "assess_risks")
+    graph.add_edge("assess_risks", "prepare_response")
 
     graph.add_edge("prepare_response", END)
 
     return graph.compile()
 
 
-def risk_workflow(request: RiskRequest, use_full_workflow: bool = True) -> RiskResponse:
+def risk_workflow(request: RiskRequest) -> RiskResponse:
     """
     Run the risk workflow and return a structured response.
 
     This workflow orchestrates:
-    1. Web search for relevant context (if use_full_workflow=True)
-    2. Document retrieval from the document microservice (if use_full_workflow=True)
+    1. Web search for relevant context
+    2. Document retrieval from the document microservice
     3. Risk identification (using direct implementation to avoid circular dependency)
-    4. Risk assessment (if use_full_workflow=True)
+    4. Risk assessment
 
     Args:
         request: The risk request containing business context and category
-        use_full_workflow: Whether to use the full workflow capabilities (search, document integration)
-                          or a simpler version similar to the legacy chains. Default is True.
 
     Returns:
         A risk response containing identified risks and document references
     """
-    app = _build_risk_workflow_graph(request, use_full_workflow)
+    app = _build_risk_workflow_graph(request)
     result = app.invoke({"request": request})
     return result["response"]
 
 
-async def async_risk_workflow(
-    request: RiskRequest, use_full_workflow: bool = True
-) -> RiskResponse:
+async def async_risk_workflow(request: RiskRequest) -> RiskResponse:
     """
     Asynchronous version of the risk workflow.
 
     Args:
         request: The risk request containing business context and category
-        use_full_workflow: Whether to use the full workflow capabilities (search, document integration)
-                          or a simpler version similar to the legacy chains. Default is True.
 
     Returns:
         A risk response containing identified risks and document references
     """
-    app = _build_risk_workflow_graph(request, use_full_workflow)
+    app = _build_risk_workflow_graph(request)
     result = await app.ainvoke({"request": request})
     return result["response"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,15 +3,18 @@ import sys
 
 from riskgpt.registry.chain_registry import available, get
 
-# Force reload of the chains module to ensure decorators are applied
-if "riskgpt.chains" in sys.modules:
-    del sys.modules["riskgpt.chains"]
 
-# Import chains package to trigger registration via decorators
-importlib.import_module("riskgpt.chains")
+def _reload_chains():
+    """Reload chain modules so decorators register functions."""
+    if "riskgpt.chains" in sys.modules:
+        del sys.modules["riskgpt.chains"]
+        for mod in [m for m in list(sys.modules) if m.startswith("riskgpt.chains.")]:
+            del sys.modules[mod]
+    importlib.import_module("riskgpt.chains")
 
 
 def test_registry_contains_get_categories():
+    _reload_chains()
     assert "get_categories" in available()
     func = get("get_categories")
     assert callable(func)

--- a/tests/test_risk_workflow.py
+++ b/tests/test_risk_workflow.py
@@ -142,37 +142,6 @@ def test_risk_workflow_with_mocked_document_service(mock_fetch):
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
-def test_risk_workflow_simple_mode():
-    """Test the risk workflow in simple mode (without full workflow capabilities)."""
-    # Create a request
-    request = RiskRequest(
-        business_context=BusinessContext(
-            project_id="123",
-            project_description="A new IT project to implement a CRM system.",
-            domain_knowledge="The company operates in the B2B sector.",
-            language=LanguageEnum.english,
-        ),
-        category="Technical",
-        existing_risks=["Data loss"],
-    )
-
-    # Run the workflow in simple mode
-    response = risk_workflow(request, use_full_workflow=False)
-
-    # Check that we have risks but no assessments
-    assert isinstance(response.risks, list)
-    assert len(response.risks) > 0
-    assert response.risks[0].title
-    assert response.risks[0].description
-    assert response.risks[0].category
-
-    # In simple mode, document_refs should not be present
-    assert not hasattr(response, "document_refs") or response.document_refs is None
-
-
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
-)
 @patch("riskgpt.workflows.risk_workflow.perform_search")
 def test_risk_workflow_with_search(mock_search):
     """Test the risk workflow with search functionality."""


### PR DESCRIPTION
## Summary
- drop `use_full_workflow` option
- always run the full risk workflow
- remove simple mode unit test and update registry test
- document workflow without simple mode
- note removal in changelog

## Testing
- `black riskgpt/workflows/risk_workflow.py tests/test_risk_workflow.py tests/test_registry.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684827eb136c832dbeddb070af5260d4