### PR TITLE
Remove simple mode mentions from docs

### DIFF
--- a/docs/risk_workflow.md
+++ b/docs/risk_workflow.md
@@ -6,12 +6,12 @@ The Risk Workflow orchestrates the risk identification and assessment process, i
 
 The Risk Workflow combines multiple steps into a single workflow:
 
-1. Web search for relevant context (when using full workflow)
-2. Document retrieval from the document microservice (when using full workflow)
+1. Web search for relevant context
+2. Document retrieval from the document microservice
 3. Risk identification (using direct implementation to avoid circular dependency)
-4. Risk assessment (when using full workflow)
+4. Risk assessment
 
-This workflow is designed to replace the individual chains with a more integrated approach that can leverage web search results and document references. It also provides a simpler mode that skips the search, document integration, and assessment steps for faster processing.
+This workflow is designed to replace the individual chains with a more integrated approach that can leverage web search results and document references.
 
 ## Usage
 
@@ -33,11 +33,8 @@ request = RiskRequest(
     existing_risks=["Data migration failure"],
 )
 
-# Run the workflow with full capabilities (default)
+# Run the workflow
 response = risk_workflow(request)
-
-# Or run in simple mode (faster, no search or assessment)
-simple_response = risk_workflow(request, use_full_workflow=False)
 
 # Access the results
 for risk in response.risks:
@@ -48,11 +45,11 @@ for risk in response.risks:
         print(f"Document References: {risk.document_refs}")
     print("---")
 
-# Access document references in the response (only available in full workflow mode)
+# Access document references in the response
 if response.document_refs:
     print(f"Document References: {response.document_refs}")
 
-# Access search references in the response (only available in full workflow mode)
+# Access search references in the response
 if response.references:
     print(f"Search References: {response.references}")
 ```
@@ -67,11 +64,8 @@ async def main():
     # Create a request (same as above)
     # ...
 
-    # Run the workflow asynchronously with full capabilities
+    # Run the workflow asynchronously
     response = await async_risk_workflow(request)
-
-    # Or run in simple mode (faster, no search or assessment)
-    simple_response = await async_risk_workflow(request, use_full_workflow=False)
 
     # Access the results (same as above)
     # ...
@@ -84,8 +78,8 @@ asyncio.run(main())
 The workflow includes integration with web search providers to find relevant context for risk identification. This uses the same search functionality as the external_context_enrichment workflow.
 
 ```python
-# The search is performed automatically when using the full workflow
-response = risk_workflow(request, use_full_workflow=True)
+# The search is performed automatically
+response = risk_workflow(request)
 
 # Access search references in the response
 if response.references:

--- a/docs/schemas_assessment.md
+++ b/docs/schemas_assessment.md
@@ -186,7 +186,7 @@ if response.quantitative:
 
 ### Assessment in Risk Workflow
 
-The assessment models are also used in the risk workflow when `use_full_workflow=True`:
+The assessment models are also used in the risk workflow:
 
 ```python
 from riskgpt.models.schemas import BusinessContext, RiskRequest
@@ -203,8 +203,8 @@ request = RiskRequest(
     max_risks=5,
 )
 
-# Run the workflow with full capabilities (includes assessment)
-response = risk_workflow(request, use_full_workflow=True)
+# Run the workflow (includes assessment)
+response = risk_workflow(request)
 
 # The assessments are performed internally in the workflow
 # but are not directly accessible in the response

--- a/riskgpt/workflows/risk_workflow.py
+++ b/riskgpt/workflows/risk_workflow.py
@@ -97,14 +97,7 @@ def _identify_risks_directly(request: RiskRequest) -> RiskResponse:
 
 
 def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = True):
-    """
-    Build and compile the risk workflow graph.
-
-    Args:
-        request: The risk request containing business context and category
-        use_full_workflow: Whether to use the full workflow capabilities (search, document integration)
-                          or a simpler version similar to the legacy chains
-    """
+    """Build and compile the risk workflow graph."""
     if StateGraph is None:
         raise ImportError("langgraph is required for this workflow")
 
@@ -325,19 +318,16 @@ def _build_risk_workflow_graph(request: RiskRequest, use_full_workflow: bool = T
 
 
 def risk_workflow(request: RiskRequest, use_full_workflow: bool = True) -> RiskResponse:
-    """
-    Run the risk workflow and return a structured response.
+    """Run the risk workflow and return a structured response.
 
     This workflow orchestrates:
-    1. Web search for relevant context (if use_full_workflow=True)
-    2. Document retrieval from the document microservice (if use_full_workflow=True)
+    1. Web search for relevant context
+    2. Document retrieval from the document microservice
     3. Risk identification (using direct implementation to avoid circular dependency)
-    4. Risk assessment (if use_full_workflow=True)
+    4. Risk assessment
 
     Args:
         request: The risk request containing business context and category
-        use_full_workflow: Whether to use the full workflow capabilities (search, document integration)
-                          or a simpler version similar to the legacy chains. Default is True.
 
     Returns:
         A risk response containing identified risks and document references
@@ -350,13 +340,10 @@ def risk_workflow(request: RiskRequest, use_full_workflow: bool = True) -> RiskR
 async def async_risk_workflow(
     request: RiskRequest, use_full_workflow: bool = True
 ) -> RiskResponse:
-    """
-    Asynchronous version of the risk workflow.
+    """Asynchronous version of the risk workflow.
 
     Args:
         request: The risk request containing business context and category
-        use_full_workflow: Whether to use the full workflow capabilities (search, document integration)
-                          or a simpler version similar to the legacy chains. Default is True.
 
     Returns:
         A risk response containing identified risks and document references

--- a/tests/test_risk_workflow.py
+++ b/tests/test_risk_workflow.py
@@ -142,8 +142,8 @@ def test_risk_workflow_with_mocked_document_service(mock_fetch):
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
-def test_risk_workflow_simple_mode():
-    """Test the risk workflow in simple mode (without full workflow capabilities)."""
+def test_risk_workflow_basic():
+    """Test the risk workflow with additional features disabled."""
     # Create a request
     request = RiskRequest(
         business_context=BusinessContext(
@@ -156,7 +156,7 @@ def test_risk_workflow_simple_mode():
         existing_risks=["Data loss"],
     )
 
-    # Run the workflow in simple mode
+    # Run the workflow with features disabled
     response = risk_workflow(request, use_full_workflow=False)
 
     # Check that we have risks but no assessments
@@ -166,7 +166,7 @@ def test_risk_workflow_simple_mode():
     assert response.risks[0].description
     assert response.risks[0].category
 
-    # In simple mode, document_refs should not be present
+    # Document references should not be present when features are disabled
     assert not hasattr(response, "document_refs") or response.document_refs is None
 
 


### PR DESCRIPTION
## Summary
- purge references to `use_full_workflow` or "simple mode" in docs
- adjust risk workflow examples to call `risk_workflow(request)`
- drop parameter details from workflow docstrings
- update test description for clarity

## Testing
- `mkdocs build > /tmp/mkdocs_build.log 2>&1 && tail -n 20 /tmp/mkdocs_build.log`

------
https://chatgpt.com/codex/tasks/task_e_684827eda3c8832d9ce4f6edb57f2064