### PR TITLE
Integrate document service

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ RiskGPT loads configuration from environment variables using a `.env` file at th
 | `INCLUDE_WIKIPEDIA` | `False` | Whether to include Wikipedia results in addition to the primary search provider. |
 | `GOOGLE_CSE_ID` | – | Google Custom Search Engine ID. Required when `SEARCH_PROVIDER` is set to `google`. |
 | `GOOGLE_API_KEY` | – | Google API key. Required when `SEARCH_PROVIDER` is set to `google`. |
+| `DOCUMENT_SERVICE_URL` | – | Base URL of the document search service used by `fetch_relevant_documents`. |
 
 ## License
 

--- a/docs/risk_workflow.md
+++ b/docs/risk_workflow.md
@@ -96,7 +96,7 @@ The search query is constructed from the business context and risk category, and
 
 ## Document Microservice Integration
 
-The workflow includes integration with a document microservice that provides relevant documents based on the business context. This integration is currently implemented as a placeholder that will be replaced with actual API calls in the future.
+The workflow integrates with a document microservice that exposes a `/search` endpoint. The service URL is configured via the `DOCUMENT_SERVICE_URL` environment variable. When set, `fetch_relevant_documents` sends the business context to this endpoint and returns the list of document IDs. If the service is unavailable, the circuit breaker returns an empty list.
 
 ```python
 from riskgpt.workflows import fetch_relevant_documents

--- a/riskgpt/config/settings.py
+++ b/riskgpt/config/settings.py
@@ -25,6 +25,9 @@ class RiskGPTSettings(BaseSettings):
     GOOGLE_CSE_ID: Optional[str] = None
     GOOGLE_API_KEY: Optional[SecretStr] = None
 
+    # Document service settings
+    DOCUMENT_SERVICE_URL: Optional[str] = None
+
     @field_validator("MEMORY_TYPE")
     @classmethod
     def validate_memory_type(cls, v: str) -> str:

--- a/riskgpt/registry/chain_registry.py
+++ b/riskgpt/registry/chain_registry.py
@@ -50,6 +50,19 @@ def get(name: str) -> Callable:
 
 def available() -> List[str]:
     """Return a sorted list of available chain names."""
+    if not _CHAIN_REGISTRY:
+        try:  # Lazy import to populate registry
+            import importlib
+            import sys
+
+            pkg = importlib.import_module("riskgpt.chains")
+            importlib.reload(pkg)
+
+            for name in list(sys.modules):
+                if name.startswith("riskgpt.chains."):
+                    importlib.reload(sys.modules[name])
+        except Exception:
+            pass
     return sorted(_CHAIN_REGISTRY)
 
 

--- a/riskgpt/utils/__init__.py
+++ b/riskgpt/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility modules for RiskGPT."""
 
 from riskgpt.utils.circuit_breaker import (
+    document_service_breaker,
     duckduckgo_breaker,
     openai_breaker,
     with_fallback,
@@ -13,6 +14,7 @@ __all__ = [
     "get_memory",
     "load_prompt",
     "load_system_prompt",
+    "document_service_breaker",
     "openai_breaker",
     "register_memory_backend",
     "with_fallback",

--- a/riskgpt/utils/circuit_breaker.py
+++ b/riskgpt/utils/circuit_breaker.py
@@ -64,6 +64,11 @@ if PYBREAKER_AVAILABLE:
         fail_max=3,  # Number of failures before opening the circuit
         reset_timeout=30,  # Seconds before attempting to close the circuit
     )
+
+    document_service_breaker = pybreaker.CircuitBreaker(
+        fail_max=3,
+        reset_timeout=30,
+    )
 else:
     # Dummy circuit breakers that always allow calls
     class DummyBreaker:
@@ -74,6 +79,7 @@ else:
     duckduckgo_breaker = DummyBreaker()
     google_search_breaker = DummyBreaker()
     wikipedia_breaker = DummyBreaker()
+    document_service_breaker = DummyBreaker()
 
 # Add monitoring for circuit state changes
 if PYBREAKER_AVAILABLE:
@@ -92,10 +98,11 @@ if PYBREAKER_AVAILABLE:
     duckduckgo_breaker.add_listener(CircuitStateListener())
     google_search_breaker.add_listener(CircuitStateListener())
     wikipedia_breaker.add_listener(CircuitStateListener())
+    document_service_breaker.add_listener(CircuitStateListener())
 
 
 def with_fallback(
-    fallback_func: Callable[..., T]
+    fallback_func: Callable[..., T],
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorator that provides a fallback function when the circuit is open.
 

--- a/tests/test_risk_workflow.py
+++ b/tests/test_risk_workflow.py
@@ -87,8 +87,14 @@ async def test_async_risk_workflow():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
-def test_fetch_relevant_documents():
-    """Test the placeholder function for fetching relevant documents."""
+@patch("riskgpt.workflows.risk_workflow.requests.post")
+def test_fetch_relevant_documents(mock_post):
+    """Test fetching documents via the HTTP service."""
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "documents": ["doc-uuid-001", "doc-uuid-002"]
+    }
+
     context = BusinessContext(
         project_id="123",
         project_description="A new IT project to implement a CRM system.",
@@ -96,11 +102,9 @@ def test_fetch_relevant_documents():
         language=LanguageEnum.english,
     )
 
-    # The function should return a list of document UUIDs
     docs = fetch_relevant_documents(context)
-    assert isinstance(docs, list)
-    assert len(docs) > 0
-    assert isinstance(docs[0], str)
+    assert docs == ["doc-uuid-001", "doc-uuid-002"]
+    mock_post.assert_called_once()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add `DOCUMENT_SERVICE_URL` setting
- wire up document microservice via HTTP with circuit breaker
- reload chain modules when registry is empty
- mock HTTP calls in tests
- document the document service URL

## Testing
- `ruff check riskgpt tests --fix`
- `black riskgpt/config/settings.py riskgpt/registry/chain_registry.py riskgpt/utils/__init__.py riskgpt/utils/circuit_breaker.py riskgpt/workflows/risk_workflow.py tests/test_risk_workflow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684827ed0df0832d9fccd1dd6854bd01