### PR TITLE
Mark integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Run the full test suite locally with:
 pytest --cov=riskgpt
 ```
 
+Integration tests that require real external services are marked with
+`integration`. Run them explicitly with:
+
+```bash
+pytest -m integration
+```
+
+Unit tests run without this marker.
+
 ## Circuit Breaker Pattern
 
 RiskGPT implements a circuit breaker pattern for external API calls to handle service outages gracefully. The circuit breaker prevents sending requests to services that are likely to fail, reducing latency and conserving resources. It also allows the application to degrade gracefully when external services are unavailable.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests requiring real external services

--- a/tests/test_async_chains.py
+++ b/tests/test_async_chains.py
@@ -10,6 +10,7 @@ from riskgpt.models.schemas import BusinessContext, CategoryRequest, LanguageEnu
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_async_get_categories_chain():
     request = CategoryRequest(
         business_context=BusinessContext(

--- a/tests/test_bias_check.py
+++ b/tests/test_bias_check.py
@@ -9,6 +9,7 @@ from riskgpt.models.schemas import BiasCheckRequest, BusinessContext
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_bias_check_chain():
     request = BiasCheckRequest(
         business_context=BusinessContext(project_id="test_bias"),

--- a/tests/test_check_definition.py
+++ b/tests/test_check_definition.py
@@ -20,6 +20,7 @@ from riskgpt.models.schemas import (
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_check_definition_chain():
     """Test the check_definition_chain function."""
     request = DefinitionCheckRequest(
@@ -41,6 +42,7 @@ def test_check_definition_chain():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_async_check_definition_chain():
     """Test the async_check_definition_chain function."""
     request = DefinitionCheckRequest(
@@ -62,6 +64,7 @@ def test_async_check_definition_chain():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_check_definition_chain_with_passive_voice():
     """Test the check_definition_chain function with passive voice."""
     request = DefinitionCheckRequest(
@@ -79,6 +82,7 @@ def test_check_definition_chain_with_passive_voice():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_check_definition_chain_missing_quantifiers():
     """Test the check_definition_chain function with missing quantifiers."""
     request = DefinitionCheckRequest(

--- a/tests/test_cost_benefit.py
+++ b/tests/test_cost_benefit.py
@@ -21,6 +21,7 @@ from riskgpt.models.schemas import (
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_cost_benefit_chain():
     """Test the cost_benefit_chain function."""
     request = CostBenefitRequest(
@@ -46,6 +47,7 @@ def test_cost_benefit_chain():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_async_cost_benefit_chain():
     """Test the async_cost_benefit_chain function."""
     request = CostBenefitRequest(

--- a/tests/test_external_context_enrichment.py
+++ b/tests/test_external_context_enrichment.py
@@ -7,6 +7,7 @@ from riskgpt.models.schemas import BusinessContext, ExternalContextRequest
 from riskgpt.workflows import external_context_enrichment
 
 
+@pytest.mark.integration
 def test_external_context_enrichment_basic():
     req = ExternalContextRequest(
         business_context=BusinessContext(
@@ -27,6 +28,7 @@ def test_external_context_enrichment_missing_param():
         ExternalContextRequest()
 
 
+@pytest.mark.integration
 def test_external_context_sources_have_url():
     req = ExternalContextRequest(
         business_context=BusinessContext(
@@ -40,6 +42,7 @@ def test_external_context_sources_have_url():
         assert src.get("url")
 
 
+@pytest.mark.integration
 def test_external_context_demo_company():
     req = ExternalContextRequest(
         business_context=BusinessContext(
@@ -60,6 +63,7 @@ def test_external_context_demo_company():
     or os.environ.get("INCLUDE_WIKIPEDIA", "").lower() != "true",
     reason="Google API key, CSE ID, or Wikipedia integration not set",
 )
+@pytest.mark.integration
 def test_external_context_with_google_and_wikipedia():
     """Test the workflow with Google Custom Search API and Wikipedia."""
 

--- a/tests/test_get_assessment.py
+++ b/tests/test_get_assessment.py
@@ -9,6 +9,7 @@ from riskgpt.models.schemas import AssessmentRequest, BusinessContext
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_get_assessment_chain():
     request = AssessmentRequest(
         business_context=BusinessContext(project_id="123", language="de"),

--- a/tests/test_get_categories.py
+++ b/tests/test_get_categories.py
@@ -9,6 +9,7 @@ from riskgpt.models.schemas import BusinessContext, CategoryRequest
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_get_categories_chain():
     request = CategoryRequest(
         business_context=BusinessContext(

--- a/tests/test_get_correlation_tags.py
+++ b/tests/test_get_correlation_tags.py
@@ -9,6 +9,7 @@ from riskgpt.models.schemas import BusinessContext, CorrelationTagRequest
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_get_correlation_tags_chain():
     request = CorrelationTagRequest(
         business_context=BusinessContext(

--- a/tests/test_get_mitigations.py
+++ b/tests/test_get_mitigations.py
@@ -9,6 +9,7 @@ from riskgpt.models.schemas import BusinessContext, MitigationRequest
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_get_mitigations_chain():
     request = MitigationRequest(
         business_context=BusinessContext(

--- a/tests/test_get_risks.py
+++ b/tests/test_get_risks.py
@@ -9,6 +9,7 @@ from riskgpt.models.schemas import BusinessContext, LanguageEnum, RiskRequest
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_get_risks_chain():
     request = RiskRequest(
         business_context=BusinessContext(

--- a/tests/test_prepare_presentation_audience.py
+++ b/tests/test_prepare_presentation_audience.py
@@ -22,6 +22,7 @@ audiences = [
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
 @pytest.mark.parametrize("audience", audiences)
+@pytest.mark.integration
 def test_prepare_presentation_all_audiences(audience, monkeypatch):
     # If OPENAI_API_KEY is not set, mock the prepare_presentation_output function
     if not os.environ.get("OPENAI_API_KEY"):

--- a/tests/test_risk_workflow.py
+++ b/tests/test_risk_workflow.py
@@ -11,6 +11,7 @@ from riskgpt.workflows import async_risk_workflow, risk_workflow
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_risk_workflow_basic():
     """Test the basic functionality of the risk workflow."""
     request = RiskRequest(
@@ -34,6 +35,7 @@ def test_risk_workflow_basic():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_risk_workflow_with_document_refs():
     """Test the risk workflow with document references."""
     # Create a request with document_refs
@@ -64,6 +66,7 @@ def test_risk_workflow_with_document_refs():
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
 @pytest.mark.asyncio
+@pytest.mark.integration
 async def test_async_risk_workflow():
     """Test the async version of the risk workflow."""
     request = RiskRequest(
@@ -84,6 +87,7 @@ async def test_async_risk_workflow():
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
+@pytest.mark.integration
 def test_fetch_documents():
     """Test the placeholder function for fetching documents."""
 
@@ -105,6 +109,7 @@ def test_fetch_documents():
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
 @patch("riskgpt.workflows.risk_workflow.fetch_documents")
+@pytest.mark.integration
 def test_risk_workflow_with_mocked_document_service(mock_fetch):
     """Test the risk workflow with a mocked document service."""
     # Mock the document service to return specific UUIDs
@@ -141,6 +146,7 @@ def test_risk_workflow_with_mocked_document_service(mock_fetch):
     not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
 )
 @patch("riskgpt.workflows.risk_workflow.search_context")
+@pytest.mark.integration
 def test_risk_workflow_with_search(mock_search):
     """Test the risk workflow with search functionality."""
     # Mock the search function to return specific results

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,6 +14,7 @@ from riskgpt.utils.search import (
     not os.environ.get("GOOGLE_API_KEY") or not os.environ.get("GOOGLE_CSE_ID"),
     reason="Google API key or CSE ID not set",
 )
+@pytest.mark.integration
 def test_google_search():
     """Test Google Custom Search API."""
     query = "artificial intelligence"
@@ -34,6 +35,7 @@ def test_google_search():
     or os.environ.get("INCLUDE_WIKIPEDIA", "").lower() != "true",
     reason="Wikipedia integration not enabled",
 )
+@pytest.mark.integration
 def test_wikipedia_search():
     """Test Wikipedia search."""
 
@@ -58,6 +60,7 @@ def test_wikipedia_search():
     or os.environ.get("INCLUDE_WIKIPEDIA", "").lower() != "true",
     reason="Google API key, CSE ID, or Wikipedia integration not set",
 )
+@pytest.mark.integration
 def test_combined_search():
     """Test combined search with Google and Wikipedia."""
 


### PR DESCRIPTION
## Summary
- add pytest.ini for integration marker
- mark tests calling external services with `@pytest.mark.integration`
- document integration test usage

## Testing
- `pre-commit run --files README.md pytest.ini tests/test_async_chains.py tests/test_bias_check.py tests/test_check_definition.py tests/test_cost_benefit.py tests/test_external_context_enrichment.py tests/test_get_assessment.py tests/test_get_categories.py tests/test_get_correlation_tags.py tests/test_get_mitigations.py tests/test_get_risks.py tests/test_prepare_presentation_audience.py tests/test_risk_workflow.py tests/test_search.py`
- `pytest -m "not integration" -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_68487b70fa98832d944160864744ffee