### PR TITLE
Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,21 @@ Run the full test suite locally with:
 pytest --cov=riskgpt
 ```
 
-Integration tests that require real external services are marked with
-`integration`. Run them explicitly with:
+Unit tests run by default when executing `pytest`:
+
+```bash
+pytest
+```
+
+Integration tests require real external services and valid API keys. Set the
+environment variables first, for example:
+
+```bash
+export OPENAI_API_KEY=sk-test-123
+export DOCUMENT_SERVICE_URL=https://example.com
+```
+
+Then run the integration suite explicitly:
 
 ```bash
 pytest -m integration


### PR DESCRIPTION
## Summary
- clarify that unit tests run by default with `pytest`
- explain running integration tests with valid API keys
- add command examples showing environment variables

## Testing
- `pytest -m "not integration"` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_6848822660e8832d81c259318f73ead8